### PR TITLE
Pynt på tekst, eksplisitt på hvilken verdi man prøver å vise

### DIFF
--- a/observability/alerts/recommended_alerts.md
+++ b/observability/alerts/recommended_alerts.md
@@ -17,19 +17,19 @@ spec:
     - alert: applikasjon nede
       expr: up{app="<appname>", job="kubernetes-pods"} == 0
       for: 2m
-      description: "{{ $labels.app }} er nede i {{ $labels.kubernetes_namespace }}"
+      description: "App {{ $labels.app }} er nede i namespace {{ $labels.kubernetes_namespace }}"
       action: "`kubectl describe pod {{ $labels.kubernetes_pod_name }} -n {{ $labels.kubernetes_namespace }}` for events, og `kubectl logs {{ $labels.kubernetes_pod_name }} -n {{ $labels.kubernetes_namespace }}` for logger"
     - alert: høy feilrate i logger
       expr: (100 * sum by (log_app, log_namespace) (rate(logd_messages_total{log_app="<appname>",log_level=~"Warning|Error"}[3m])) / sum by (log_app, log_namespace) (rate(logd_messages_total{log_app="<appname>"}[3m]))) > 10
       for: 3m
-      action: "Sjekk loggene til {{ $labels.log_app }} i {{ $labels.log_namespace }}, for å se hvorfor det er så mye feil"
+      action: "Sjekk loggene til app {{ $labels.log_app }} i namespace {{ $labels.log_namespace }}, for å se hvorfor det er så mye feil"
     - alert: feil i selftest
       expr: selftests_aggregate_result_status{app="<appname>"} > 0
       for: 1m
-      action: "Sjekk {{ $labels.app }} i {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
+      action: "Sjekk app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} sine selftest for å se hva som er galt"
 # Java-spesifikk
     - alert: høy feilrate for http-requester
       expr: (100 * sum by (app, kubernetes_namespace) (rate(jetty_responses_total{app="<appname>",code=~"1xx|2xx|3xx"}[3m])) / sum by (app, kubernetes_namespace) (rate(jetty_requests_total{app="<appname>"}[3m]))) < 90
       for: 3m
-      action: "Sjekk loggene til {{ $labels.app }} i {{ $labels.kubernetes_namespace }} for å se hvorfor mange http-requests feiler"
+      action: "Sjekk loggene til app {{ $labels.app }} i namespace {{ $labels.kubernetes_namespace }} for å se hvorfor mange http-requests feiler"
 ```


### PR DESCRIPTION
Dette er sikkert en lite viktig smak-og-behag-ting, men jeg liker å si hvilken verdi som printes før jeg printer den. Det vil forbedre disse ikke-så-pene alert-meldingene jeg har fått i Slack:
```
[FIRING:1]
finn-kandidat-api er nede in dev-fss
er nede i 
action: kubectl describe pod  -n  for events, og kubectl logs  -n  for logger
```
```
[FIRING:1]
høy feilrate i logger in dev-fss
@here | 
action: Sjekk loggene til rekrutteringsbistand-api i default, for å se hvorfor det er så mye feil
```