### PR TITLE
Update examples with team namespaces

### DIFF
--- a/addons/azure-ad.md
+++ b/addons/azure-ad.md
@@ -40,7 +40,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: nais-testapp
-  namespace: default
+  namespace: aura
   labels:
     team: aura
 spec:
@@ -69,7 +69,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: nais-testapp
-  namespace: default
+  namespace: aura
   labels:
     team: aura
 spec:

--- a/basics/application.md
+++ b/basics/application.md
@@ -12,7 +12,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: appname
-  namespace: default
+  namespace: teamname
   labels:
     team: teamname
 spec:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -90,7 +90,7 @@ apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
   name: myapplication
-  namespace: default
+  namespace: myteam
   labels:
     team: myteam
 spec:
@@ -255,7 +255,7 @@ Now, create a `vars.yml` file containing variables for your deployment:
 
 ```yaml
 app: myapplication
-namespace: default
+namespace: myteam
 team: myteam
 image: docker.pkg.github.com/navikt/myapplication/myapplication:latest
 ingresses:

--- a/nais-application/manifest.md
+++ b/nais-application/manifest.md
@@ -14,7 +14,7 @@ Which namespace the application will be deployed to.
 **Default**: default
 
 {% hint style="info" title="Note" %}
-It is recommended to use [team namespaces](../clusters/team-namespaces.md) instead of default.
+It is recommended to use [team namespaces](../clusters/team-namespaces.md) instead of using the default namespace.
 {% endhint %}
 
 ## `metadata.labels.team`

--- a/nais-application/manifest.md
+++ b/nais-application/manifest.md
@@ -13,6 +13,10 @@ Which namespace the application will be deployed to.
 
 **Default**: default
 
+{% hint style="info" title="Note" %}
+It is recommended to use [team namespaces](../clusters/team-namespaces.md) instead of default.
+{% endhint %}
+
 ## `metadata.labels.team`
 The name of the [team](../basics/teams.md) that owns this application (lowercase only!).
 

--- a/nais-application/max-example.md
+++ b/nais-application/max-example.md
@@ -8,7 +8,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: nais-testapp
-  namespace: default
+  namespace: aura
   labels:
     team: aura
 spec:

--- a/nais-application/min-example.md
+++ b/nais-application/min-example.md
@@ -8,7 +8,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: nais-testapp
-  namespace: default
+  namespace: aura
   labels:
     team: aura
 spec:


### PR DESCRIPTION
it is to my understanding that team namespaces are generally recommended practice for those who have the chance to migrate

as such, the examples around the documentation should reflect that as a best practice for those who might reference them for their own configurations

i may have been a bit overzealous with changing the examples, so have a quick look to see if i haven't changed an alert (which afaik should stay in `default`) or something