### PR TITLE
Update section referencing non-existent documentation/differences.

### DIFF
--- a/clusters/migrating-to-gcp.md
+++ b/clusters/migrating-to-gcp.md
@@ -27,9 +27,6 @@ Tokendings is finding its way into production, but not yet ready for prime time.
 The documentation will be updated when Tokendings is publicly available.
 {% endhint %}
 
-### Deploy
-Same mechanism as for on-premise clusters. See [GCP clusters][GCP].
-
 ### Ingress
 See [GCP clusters][GCP].
 

--- a/clusters/migrating-to-gcp.md
+++ b/clusters/migrating-to-gcp.md
@@ -28,7 +28,7 @@ The documentation will be updated when Tokendings is publicly available.
 {% endhint %}
 
 ### Deploy
-The same deployment mechanism is leveraged for both on-premise K8s clusters and the others GCP.
+The same deployment mechanism is leveraged for both on-premise and GCP K8s clusters.
 See [deployment] section of the documentation for how to leverage the _NAIS deploy tool_.
 
 ### Ingress

--- a/clusters/migrating-to-gcp.md
+++ b/clusters/migrating-to-gcp.md
@@ -27,6 +27,10 @@ Tokendings is finding its way into production, but not yet ready for prime time.
 The documentation will be updated when Tokendings is publicly available.
 {% endhint %}
 
+### Deploy
+The same deployment mechanism is leveraged for both on-premise K8s clusters and the others non-on-premise.
+See [Deployment][deployment] section of the documentation for how to leverage the _NAIS deploy tool_.
+
 ### Ingress
 See [GCP clusters][GCP].
 
@@ -134,6 +138,7 @@ See [laws and regulations](./laws-and-regulations.md) for details
 [GCP]: ./gcp.md
 [ROS & PVK]: ./gcp.md#ros-and-pvk
 [on-premises]: ./on-premises.md
+[deployment]: ../deployment/README.md
 [tokendings]: https://github.com/nais/tokendings
 [zero-trust]: https://github.com/navikt/pig/blob/master/kubeops/doc/zero-trust.md
 [buckets]: ../persistence/buckets.md

--- a/clusters/migrating-to-gcp.md
+++ b/clusters/migrating-to-gcp.md
@@ -29,7 +29,7 @@ The documentation will be updated when Tokendings is publicly available.
 
 ### Deploy
 The same deployment mechanism is leveraged for both on-premise K8s clusters and the others GCP.
-See [Deployment][deployment] section of the documentation for how to leverage the _NAIS deploy tool_.
+See [deployment] section of the documentation for how to leverage the _NAIS deploy tool_.
 
 ### Ingress
 See [GCP clusters][GCP].

--- a/clusters/migrating-to-gcp.md
+++ b/clusters/migrating-to-gcp.md
@@ -28,7 +28,7 @@ The documentation will be updated when Tokendings is publicly available.
 {% endhint %}
 
 ### Deploy
-The same deployment mechanism is leveraged for both on-premise K8s clusters and the others non-on-premise.
+The same deployment mechanism is leveraged for both on-premise K8s clusters and the others GCP.
 See [Deployment][deployment] section of the documentation for how to leverage the _NAIS deploy tool_.
 
 ### Ingress


### PR DESCRIPTION
There's no longer any reference in the GCP document for how the
application deployment mechanism for on-premise clusers works.