### PR TITLE
redis: update examples and fix secure redis configuration

### DIFF
--- a/persistence/redis.md
+++ b/persistence/redis.md
@@ -186,7 +186,7 @@ env:
 #### Redis metrics
 
 If you want metrics from a Redis instance running on NAIS, a separate exporter must also be run. An example
-`nais.yaml` for the simplest version of such an exporter is found below. NAIS has also made a dashboard that everyone
+`nais.yaml` for the simplest version of such an exporter is found above. NAIS has also made a dashboard that everyone
 can use. The only caveat is that the exporter application needs to end its name with `redisexporter` in the
 configuration. The dashboard is called [Redis exporters]. The dashboard sorts by `addr`, enabling a single exporter
 to scrape several Redis instances.
@@ -223,12 +223,6 @@ kubectl create secret generic redis-password \
 Now that you have a secret in Kubernetes (use `kubectl describe secret redis-password` to look at it), all you have to
 do left is to mount it.
 
-{% hint style="info" %}
-
-See the `redis-secure.yaml` example in the [examples above](#example-deployments) for setting up Redis with a password from the secret you just created.
-
-{% endhint %}
-
 Then you should also mount it to any applications that connects to the Redis instance. This is done by adding the following to your `nais.yaml`.
 
 ```yaml
@@ -236,6 +230,12 @@ spec:
   envFrom:
     - secret: redis-password
 ```
+
+{% hint style="info" %}
+
+See the `redis-secure.yaml` example in the [examples above](#example-deployments) for setting up Redis with a password from the secret you just created.
+
+{% endhint %}
 
 ## Code examples
 

--- a/persistence/redis.md
+++ b/persistence/redis.md
@@ -22,6 +22,8 @@ An example Redis setup looks like this:
 
 {% code-tabs %}
 {% code-tabs-item title="redis.yaml" %}
+
+#### Vanilla Redis {#redis-vanilla}
 ```yaml
 ---
 apiVersion: "nais.io/v1alpha1"
@@ -50,6 +52,8 @@ spec:
 {% endcode-tabs-item %}
 
 {% code-tabs-item title="redis-with-metrics.yaml" %}
+
+#### Vanilla Redis with metrics {#redis-with-metrics}
 ```yaml
 ---
 apiVersion: "nais.io/v1alpha1"
@@ -107,6 +111,8 @@ spec:
 ```
 {% endcode-tabs-item %}
 {% code-tabs-item title="redis-secure.yaml" %}
+
+#### Secured Redis with metrics {#redis-secure}
 ```yaml
 ---
 apiVersion: "nais.io/v1alpha1"
@@ -193,7 +199,7 @@ to scrape several Redis instances.
 
 {% hint style="info" %}
 
-See the `redis-with-metrics.yaml` example in [examples above](#example-deployments) for setting up a configuration with the metrics exporter.
+See the [`redis-with-metrics.yaml`](#redis-with-metrics) example in [examples above](#example-deployments) for setting up a configuration with the metrics exporter.
 
 {% endhint %}
 
@@ -233,7 +239,7 @@ spec:
 
 {% hint style="info" %}
 
-See the `redis-secure.yaml` example in the [examples above](#example-deployments) for setting up Redis with a password from the secret you just created.
+See the [`redis-secure.yaml`](#redis-secure) example in the [examples above](#example-deployments) for setting up Redis with a password from the secret you just created.
 
 {% endhint %}
 


### PR DESCRIPTION
The default `redis` baseimage doesn't support setting password without supplying a `.conf` file with some expected key/value format. If you've created a secret containing `REDIS_PASSWORD` for configuring the redis metrics exporter image, then you'll have to duplicate the password value to another secret for configuring the `redis` instance itself.

We'd have to either use vanilla k8s to set the password through the command line arguments, or use a custom image that supports supplying the password. The latter involves the least amount of work, so the examples are updated to recommend using this.

Live preview here: https://doc.nais.io/v/redis-cleanup/persistence/redis