### PR TITLE
Is this a better link to ROS documentation?

### DIFF
--- a/legal/app-ros.md
+++ b/legal/app-ros.md
@@ -4,5 +4,5 @@ Before deploying any application to nais, the team owning the application must c
 
 When conducting the risk assessment, any assumptions about underlying component risks can be verified by checking the [Platform risk assessments](app-ros.md). These may also be referred to in the application risk assessment.
 
-For details about the ROS process, see the [ROS documentation](https://navno.sharepoint.com/sites/intranett-it/SitePages/Skal-du-bruke-TryggNok-for-f%C3%B8rste-gang-.aspx) (NAV internal link).
+For details about the ROS process, see the [ROS documentation](https://navno.sharepoint.com/sites/intranett-it/SitePages/IT-sikkerhet-og-risikovurderinger.aspx) (NAV internal link).
 


### PR DESCRIPTION
When I was reading this I was looking for info on what is ROS and an aswer to when do a product team need to do a ROS assessment. The old link did not answer that, this one does, or rateher the page links to other pages that does, including the page the old link pointed to. Is this an improvenment, perhaps?