### PR TITLE
feature: Add local pre-view environment with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ site/
 
 # Terraform
 .terraform/
+
+# Git folder - for .dockerignore purposes
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN pip3 --no-input install \
     --progress-bar ascii \
     poetry
 
-RUN apt update && apt install --assume-yes strace vim less
-# RUN mkdir /app && chown -R mkdocs /app
 USER mkdocs
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM library/python:3.9-slim as builder
+
+RUN useradd mkdocs \
+    --shell /bin/bash \
+    --create-home
+RUN pip3 install --upgrade pip
+RUN pip3 --no-input install \
+    --no-cache-dir \
+    --progress-bar ascii \
+    poetry
+
+RUN apt update && apt install --assume-yes strace vim less
+# RUN mkdir /app && chown -R mkdocs /app
+USER mkdocs
+WORKDIR /app
+
+COPY pyproject.toml poetry.lock ./
+RUN poetry install
+
+COPY mkdocs.yml ./
+
+ARG PORT=8080
+ENV PORT=$PORT
+EXPOSE "$PORT"
+CMD poetry run mkdocs serve \
+    --strict \
+    --config-file mkdocs.yml \
+    --dev-addr "127.0.0.1:$PORT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN useradd mkdocs \
 RUN pip3 install --upgrade pip
 RUN pip3 --no-input install \
     --no-cache-dir \
-    --progress-bar ascii \
     poetry
 
 USER mkdocs
@@ -16,12 +15,10 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN poetry install
 
-COPY mkdocs.yml ./
 
 ARG PORT=8080
 ENV PORT=$PORT
 EXPOSE "$PORT"
 CMD poetry run mkdocs serve \
-    --strict \
     --config-file mkdocs.yml \
     --dev-addr "127.0.0.1:$PORT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM library/python:3.9-slim as builder
+# Inspired by: https://medium.com/@harpalsahota/dockerizing-python-poetry-applications-1aa3acb76287
 
 RUN useradd mkdocs \
     --shell /bin/bash \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Welcome to the NAIS documentation repo!
+This repository is used to build a [mkdocs](https://www.mkdocs.org/) site hosted on https:/doc.nais.io!
+
+All _documentation_ content resides inside the [docs](docs/) folder, with the general structure of the website defined in [mkdocs.yml](mkdocs.yml)'s `nav`-yaml key.
+
+## GCP set-up
+
+#### First, ensure you're logged into GCP
+`gcloud auth login --update-adc`
+#### Then, run `terraform`
+```
+cd terraform/ 
+&& terraform init -backend-config="bucket=terraform-prod-235011" \
+&& terraform apply
+``` 
+Et voilá! Presto!
+
+## Local preview-environment set-up
+_**NB*_: Due to [limitations in the built-in](https://github.com/mkdocs/mkdocs/issues/2108) `mkdocs serve`'s hot-reload feature, the described set-up relies on dodgy Docker networking.
+
+### Requirements
+- `docker`
+- `docker-compose`
+
+### How to set-up local preview environment
+`docker-compose up --detach --build && open localhost:8080`

--- a/README.md
+++ b/README.md
@@ -3,18 +3,6 @@ This repository is used to build a [mkdocs](https://www.mkdocs.org/) site hosted
 
 All _documentation_ content resides inside the [docs](docs/) folder, with the general structure of the website defined in [mkdocs.yml](mkdocs.yml)'s `nav`-yaml key.
 
-## GCP set-up
-
-#### First, ensure you're logged into GCP
-`gcloud auth login --update-adc`
-#### Then, run `terraform`
-```
-cd terraform/ 
-&& terraform init -backend-config="bucket=terraform-prod-235011" \
-&& terraform apply
-``` 
-Et voilá! Presto!
-
 ## Local preview-environment set-up
 _**NB*_: Due to [limitations in the built-in](https://github.com/mkdocs/mkdocs/issues/2108) `mkdocs serve`'s hot-reload feature, the described set-up relies on dodgy Docker networking.
 
@@ -24,3 +12,16 @@ _**NB*_: Due to [limitations in the built-in](https://github.com/mkdocs/mkdocs/i
 
 ### How to set-up local preview environment
 `docker-compose up --detach --build && open localhost:8080`
+
+## GCP set-up
+
+#### First, ensure you're logged into GCP
+`gcloud auth login --update-adc`
+#### Then, run `terraform`
+```
+cd terraform/
+&& terraform init -backend-config="bucket=terraform-prod-235011" \
+&& terraform apply
+```
+Et voilá! Presto!
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mkdocs:
+    build:
+      context: .
+      args:
+        PORT: 8080
+    network_mode: host
+    volumes:
+      # The intention of this docker-compose file is to
+      # permit making use of `mkdocs serve` hot-reloading
+      # without turning off `--strict` flag.
+      #
+      # Ref: https://github.com/mkdocs/mkdocs/issues/2108
+      - ./docs/:/app/docs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,4 +12,4 @@ services:
       # without turning off `--strict` flag.
       #
       # Ref: https://github.com/mkdocs/mkdocs/issues/2108
-      - ./docs/:/app/docs
+      - ./:/app/


### PR DESCRIPTION
TODOS:
1. [x] Ensure `mkdocs serve` inside docker container can map to `0.0.0.0`.
   Ref: https://github.com/mkdocs/mkdocs/issues/2108
2. [x] Configure docker-compose to allow hot-reloading to work (mounting
  instead of COPY inside of `Dockerfile`).
3. [x] Write up proper how-to/documentation.