### PR TITLE
adds amplitude integration

### DIFF
--- a/docs/custom/javascript/analytics.js
+++ b/docs/custom/javascript/analytics.js
@@ -1,0 +1,3 @@
+app.location$.subscribe(function(url) {
+  amplitude.getInstance().logEvent('sidevisning', {'pathname': url.pathname})
+})

--- a/docs/custom/overrides/main.html
+++ b/docs/custom/overrides/main.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block analytics %}
+<script type="text/javascript">
+    (function (e, t) {
+        var n = e.amplitude || { _q: [], _iq: {} }; var r = t.createElement("script")
+            ; r.type = "text/javascript"
+            ; r.integrity = "sha384-girahbTbYZ9tT03PWWj0mEVgyxtZoyDF9KVZdL+R53PP5wCY0PiVUKq0jeRlMx9M"
+            ; r.crossOrigin = "anonymous"; r.async = true
+            ; r.src = "https://cdn.amplitude.com/libs/amplitude-7.2.1-min.gz.js"
+            ; r.onload = function () {
+                if (!e.amplitude.runQueuedFunctions) {
+                    console.log("[Amplitude] Error: could not load SDK")
+                }
+            }
+            ; var i = t.getElementsByTagName("script")[0]; i.parentNode.insertBefore(r, i)
+            ; function s(e, t) {
+                e.prototype[t] = function () {
+                    this._q.push([t].concat(Array.prototype.slice.call(arguments, 0))); return this
+                }
+            }
+        var o = function () { this._q = []; return this }
+            ; var a = ["add", "append", "clearAll", "prepend", "set", "setOnce", "unset"]
+            ; for (var c = 0; c < a.length; c++) { s(o, a[c]) } n.Identify = o; var u = function () {
+                this._q = []
+                    ; return this
+            }
+            ; var l = ["setProductId", "setQuantity", "setPrice", "setRevenueType", "setEventProperties"]
+            ; for (var p = 0; p < l.length; p++) { s(u, l[p]) } n.Revenue = u
+            ; var d = ["init", "logEvent", "logRevenue", "setUserId", "setUserProperties", "setOptOut", "setVersionName", "setDomain", "setDeviceId", "enableTracking", "setGlobalUserProperties", "identify", "clearUserProperties", "setGroup", "logRevenueV2", "regenerateDeviceId", "groupIdentify", "onInit", "logEventWithTimestamp", "logEventWithGroups", "setSessionId", "resetSessionId"]
+            ; function v(e) {
+                function t(t) {
+                    e[t] = function () {
+                        e._q.push([t].concat(Array.prototype.slice.call(arguments, 0)))
+                    }
+                }
+                for (var n = 0; n < d.length; n++) { t(d[n]) }
+            } v(n); n.getInstance = function (e) {
+                e = (!e || e.length === 0 ? "$default_instance" : e).toLowerCase()
+                    ; if (!n._iq.hasOwnProperty(e)) { n._iq[e] = { _q: [] }; v(n._iq[e]) } return n._iq[e]
+            }
+            ; e.amplitude = n
+    })(window, document);
+
+    amplitude.getInstance().init(document.domain === "doc.nais.io" ? "487ae1d6430543123d5da2c3467d0844" : "69f900cf5fe06368af2469ca4cf1f927", undefined, {
+        apiEndpoint: 'amplitude.nav.no/collect',
+        saveEvents: false,
+        includeUtm: true,
+        includeReferrer: true,
+        platform: window.location.toString(),
+    });
+</script>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ theme:
   language: 'en'
   logo: assets/logo.png
   favicon: assets/logo.png
+  custom_dir: docs/custom/overrides
   palette:
     scheme: preference
     primary: white
@@ -16,6 +17,8 @@ theme:
 extra:
   search:
     language: 'en'
+extra_javascript:
+  - custom/javascript/analytics.js
 plugins:
   - search
 markdown_extensions:


### PR DESCRIPTION
addresses #140 

this adds a few customizations in the form of javascript and a template extension. the changes run data through the inhouse proxy about what pages the reader looks at, e.g. `/` for the main page, `/basics/access` for access from laptop, and so on. this data point was the easiest and most sensible thing i could add in which gives us the ability to see which pages are the most popular ones.

the large code block in `docs/custom/overrides/main.html` uses the snippet described in the [amplitude sdk documentation](https://developers.amplitude.com/docs/javascript), with some inspiration taken from [navikt/tp-malekode](https://github.com/navikt/tp-malekode/blob/main/amplitude.md). the general method for extending the stack is described in the [material for mkdocs documentation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#other-analytics-providers).

i put the extension stuff inside `./docs/custom`. it seems `theme.custom_dir` has the base directory at `.`, while `extra_javascript` (and `extra_css`) has their base directories at `./docs`, so i just tried to unify them there. here's more about [customization](https://squidfunk.github.io/mkdocs-material/customization/) in material for mkdocs for those who want to check it out.

the events get posted to "nais.io - test" in amplitude when things get spun up locally (or anywhere not doc.nais.io), and to "nais.io - prod" when it is on doc.nais.io. i am uncertain whether this will work in production (see: [navikt/tp-malekode](https://github.com/navikt/tp-malekode/blob/main/amplitude.md#hvordan-installere-amplitude-i-din-app-og-logge-events), tldr: there's apparently an allowlist for domains), though @tobiasmcvey said we can just try and see. if it doesn't work, it's not the end of the world anyway, nor is it an issue on this side of things.

an example chart using "nais.io - test" can be found here (probably requires a user to see): https://analytics.amplitude.com/nav/chart/w8nj3yw