### PR TITLE
Docs: Add bigquery documentation

### DIFF
--- a/docs/persistence/bigquery.md
+++ b/docs/persistence/bigquery.md
@@ -1,0 +1,53 @@
+# Bigquery Datasets
+
+!!! info
+    This feature is only available in GCP clusters.
+
+## NAIS Application yaml manifest options
+Full documentation of all available options can be found over at: [`spec.gcp.bigQueryDatasets[]`](../../nais-application/application#gcpbigquerydatasets).
+
+Example of an application using a `nais.yaml` provisioned BigQuery Dataset can be found here: [testapp](https://github.com/nais/testapp/blob/master/pkg/bigquery/bigquery.go).
+
+## Minimal Working Example
+=== "You can request a MWE Google Cloud BiqQuery Dataset through the NAIS Application manifest like so:"
+    ```yaml
+    apiVersion: "nais.io/v1alpha1"
+    kind: "Application"
+    metadata:
+      name: app-a
+    ...
+    spec:
+      ...
+      gcp:
+        bigQueryDatasets:
+          - name: my_bigquery_dataset
+            permission: READWRITE
+    ```
+
+## Caveats to be aware of
+
+=== "Automatic Deletion"
+    Once a BigQuery Dataset is provisioned, it will not be automatically deleted - unless one explicitly sets [`spec.gcp.bigQueryDatasets[].cascadingDelete`](../../nais-application/application#gcpbigquerydatasetscascadingdelete) to `true`.
+    This means that any cleanup must be done manually.  
+    <br/>
+    When there exist no tables in the specified BigQuery Dataset, deleting the "nais application" will delete the whole BigQuery Dataset, even if [`spec.gcp.bigQueryDatasets[].cascadingDelete`](../../nais-application/application#gcpbigquerydatasetscascadingdelete) is set to `false`.
+=== "Unique names"
+    The name of your Dataset must be unique within your team's GCP project.
+=== "Updates/Immutability"
+    The NAIS Manifest does not currently support updating any setting of existing BigQuery Datasets.  
+    <br/>
+    Thus, if you want a read-connection to a already-created BigQuery Dataset, take a look at [nais/dp](https://github.com/nais/dp/#dp).
+=== "K8s resource naming"
+    Since Kubernetes does not permit underscores (`_`) in the names of any K8s resource, any underscores will be converted to hyphens (`-`).
+
+## Example with all configuration options
+
+See [full example](../nais-application/example.md).
+
+## Troubleshooting
+If you have problems getting your bucket up and running, check errors in the event log:
+
+```bash
+kubectl describe bigquerydataset my-bigquery-dataset
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,10 +84,12 @@ nav:
       - Tracing: observability/tracing.md
     - Persistence:
       - Responsibilities: persistence/responsibilities.md
-      - Buckets: persistence/buckets.md
+      - GCP storage alternatives:
+        - Buckets: persistence/buckets.md
+        - Postgres: persistence/postgres.md
+        - BigQuery: persistence/bigquery.md
       - Elastic Search: persistence/elastic-search.md
       - Influxdb: persistence/influxdb.md
-      - Postgres: persistence/postgres.md
       - S3 object store: persistence/objectstore.md
       - Redis: persistence/redis.md
       - On-premises disk: persistence/volume-storage.md


### PR DESCRIPTION
Also, move all GCP persistent storage into its own sub-heading in
navigation tree.
Co-authored-by: @cteig <christine.teig@nav.no>