### PR TITLE
Add macOS specific path

### DIFF
--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -35,7 +35,10 @@ We provide a [pre-made kubeconfig](https://github.com/navikt/kubeconfigs) file w
 `kubectl` will by default look for a file named `config` in the `$HOME/.kube/` folder. This can be overriden by having the absolute path of the file in the environment variable `KUBECONFIG`.
 
 ```bash
+# for Linux
 export KUBECONFIG="/home/$(whoami)/kubeconfigs/config"
+# for macOS
+export KUBECONFIG="$HOME/kubeconfigs/config"
 ```
 
 The above example can also be added to something like `~/.bash_profile`, or the equivalent in your preferred shell.


### PR DESCRIPTION
This has been troublesome for summer students who are not familiar with Unix as using the Linux specific command does not give any feedback.