### PR TITLE
Legg til Starship som anbefalt verktøy for å se aktiv  k8s context og namespace i terminalen

### DIFF
--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -107,6 +107,6 @@ When prompted like above, go to the address and enter the code. You then log in 
 ## Recommended tools
 
 * [kubectx](https://github.com/ahmetb/kubectx) - Simplifies changing cluster and namespace context.
-* [kubeaware](https://github.com/jhrv/kubeaware) - Visualize which cluster and namespace is currently active.
+* [kubeaware](https://github.com/jhrv/kubeaware) or [Starship](https://starship.rs/) - Visualize which cluster and namespace is currently active.
 * [emacs-kubectx-mode](https://github.com/terjesannum/emacs-kubectx-mode) - Switch kubectl context and namespace in Emacs and display current setting in mode line.
 

--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -107,7 +107,7 @@ When prompted like above, go to the address and enter the code. You then log in 
 ## Recommended tools
 
 * [kubectx](https://github.com/ahmetb/kubectx) - Simplifies changing cluster and namespace context.
-* [kubeaware](https://github.com/jhrv/kubeaware) or [Starship](https://starship.rs/) - Visualize which cluster and namespace is currently active.
+* [kubeaware](https://github.com/jhrv/kubeaware) - Visualize which cluster and namespace is currently active.
 * [Starship](https://starship.rs/) - Visualize which cluster and namespace is currently active in your terminal prompt, amongst many other things. [Kubernetes specific config](https://starship.rs/config/#kubernetes)
 * [emacs-kubectx-mode](https://github.com/terjesannum/emacs-kubectx-mode) - Switch kubectl context and namespace in Emacs and display current setting in mode line.
 

--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -108,5 +108,6 @@ When prompted like above, go to the address and enter the code. You then log in 
 
 * [kubectx](https://github.com/ahmetb/kubectx) - Simplifies changing cluster and namespace context.
 * [kubeaware](https://github.com/jhrv/kubeaware) or [Starship](https://starship.rs/) - Visualize which cluster and namespace is currently active.
+* [Starship](https://starship.rs/) - Visualize which cluster and namespace is currently active in your terminal prompt, amongst many other things. [Kubernetes specific config](https://starship.rs/config/#kubernetes)
 * [emacs-kubectx-mode](https://github.com/terjesannum/emacs-kubectx-mode) - Switch kubectl context and namespace in Emacs and display current setting in mode line.
 


### PR DESCRIPTION
Starship fungerer knirkefritt for meg i Ubuntu med bash. Starship skal i følge reklamen fungere for flere OS og flere shell. Lisens er open source og prosjektet er aktivt.