### PR TITLE
Added section about recommended alternative to InfluxDB on Aiven

### DIFF
--- a/docs/diagrams/out/persistence/bigquery-metabase.svg
+++ b/docs/diagrams/out/persistence/bigquery-metabase.svg
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentStyleType="text/css" height="219.7917px" preserveAspectRatio="none" style="width:881px;height:219px;background:#00000000;" version="1.1" viewBox="0 0 881 219" width="881.25px" zoomAndPan="magnify"><defs><linearGradient id="gaxgshl64qhey0" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0%" stop-color="#F2FCFE"/><stop offset="100%" stop-color="#EEEEEE"/></linearGradient><filter height="300%" id="faxgshl64qhey" width="300%" x="-1" y="-1"><feGaussianBlur result="blurOut" stdDeviation="2.0833333333333335"/><feColorMatrix in="blurOut" result="blurOut2" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .4 0"/><feOffset dx="4.166666666666667" dy="4.166666666666667" in="blurOut2" result="blurOut3"/><feBlend in="SourceGraphic" in2="blurOut3" mode="normal"/></filter><linearGradient id="gaxgshl64qhey1" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0%" stop-color="#4DABF5"/><stop offset="100%" stop-color="#2196F3"/></linearGradient><linearGradient id="gaxgshl64qhey2" x1="50%" x2="50%" y1="0%" y2="100%"><stop offset="0%" stop-color="#B052C0"/><stop offset="100%" stop-color="#9C27B0"/></linearGradient></defs><g><!--MD5=[633a4c6592f0035e0725e0dfdccc51a8]
+entity Metabase--><g id="elem_Metabase"><path d="M763.7029,108.4798 C767.7663,102.697 772.192,102.4624 777.047,107.5041 C781.4373,101.1107 785.7003,101.8787 789.9764,107.6257 C793.1224,102.7698 796.6929,102.8775 800.494,106.8448 C802.2458,99.2447 808.7343,98.9145 813.3506,103.9242 C818.1533,97.8006 823.663,99.816 825.9565,106.4111 C830.3508,100.6614 833.9733,100.6606 837.6298,107.1167 C841.72,102.695 847.1292,103.6523 849.329,109.3107 C853.9894,104.4149 858.3495,103.7634 861.9127,110.4979 C867.7975,113.2978 867.8974,118.5552 862.2634,121.7152 C868.2028,124.768 869.261,131.2218 863.3156,135.2018 C868.5271,140.1219 867.9113,143.5135 861.2958,146.2765 C867.736,150.3824 867.7845,155.1476 861.9314,159.8301 C859.0307,165.2775 853.6712,166.8988 849.763,160.9012 C846.698,168.2958 840.5327,168.6753 836.2042,162.1302 C833.332,167.2407 829.1743,167.845 826.0504,162.3716 C822.9486,169.5574 816.6525,169.8274 812.2528,163.7186 C808.5416,168.4851 803.9397,168.1554 801.4181,162.4839 C797.1756,169.294 791.3778,168.1679 788.2613,161.3934 C783.8754,167.0214 778.8648,166.1417 775.8492,159.9539 C772.4958,165.0686 767.6389,165.7792 763.9967,160.2763 C757.3624,157.1141 757.4279,151.2694 763.0285,147.2011 C757.6919,143.8632 757.2052,138.1554 763.0018,134.7935 C755.9962,130.9282 756.7141,125.9266 762.7283,121.7875 C756.4963,117.8546 758.0647,111.5435 763.7029,108.4798 " fill="url(#gaxgshl64qhey0)" filter="url(#faxgshl64qhey)" style="stroke:#F2FCFE;stroke-width:1.0416666666666667;"/><text fill="#222222" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="61.4583" x="781.25" y="137.6444">Metabase</text></g><!--MD5=[cec4048bf136b712678d084f71899b2d]
+entity BigQuery--><g id="elem_BigQuery"><path d="M592.7083,110.9375 C592.7083,100.5208 642.7083,100.5208 642.7083,100.5208 C642.7083,100.5208 692.7083,100.5208 692.7083,110.9375 L692.7083,155.6966 C692.7083,166.1133 642.7083,166.1133 642.7083,166.1133 C642.7083,166.1133 592.7083,166.1133 592.7083,155.6966 L592.7083,110.9375 " fill="url(#gaxgshl64qhey1)" filter="url(#faxgshl64qhey)" style="stroke:#2196F3;stroke-width:1.0416666666666667;"/><path d="M592.7083,110.9375 C592.7083,121.3542 642.7083,121.3542 642.7083,121.3542 C642.7083,121.3542 692.7083,121.3542 692.7083,110.9375 " fill="none" style="stroke:#2196F3;stroke-width:1.0416666666666667;"/><text fill="#222222" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="58.3333" x="613.5417" y="147.5403">BigQuery</text></g><!--MD5=[59ceac3e1bb6f0ece56988f2042cffc2]
+entity Kafka--><g id="elem_Kafka"><path d="M195.8333,65.625 L300,65.625 C305.2083,65.625 305.2083,88.5254 305.2083,88.5254 C305.2083,88.5254 305.2083,111.4258 300,111.4258 L195.8333,111.4258 C190.625,111.4258 190.625,88.5254 190.625,88.5254 C190.625,88.5254 190.625,65.625 195.8333,65.625 " fill="url(#gaxgshl64qhey1)" filter="url(#faxgshl64qhey)" style="stroke:#2196F3;stroke-width:1.0416666666666667;"/><path d="M300,65.625 C294.7917,65.625 294.7917,88.5254 294.7917,88.5254 C294.7917,111.4258 300,111.4258 300,111.4258 " fill="none" style="stroke:#2196F3;stroke-width:1.0416666666666667;"/><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="72.9167" x="206.25" y="92.8528">Kafka Rapid</text></g><!--MD5=[d268dfbd51d7e0491b6c4af726bbd868]
+entity bq_sink--><g id="elem_bq_sink"><rect fill="url(#gaxgshl64qhey2)" filter="url(#faxgshl64qhey)" height="52.0508" rx="4.1667" ry="4.1667" style="stroke:#9C27B0;stroke-width:1.0416666666666667;" width="162.5" x="367.7083" y="62.5"/><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="120.8333" x="388.5417" y="87.6444">BigQuery sink river</text><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="8.3333" lengthAdjust="spacing" textLength="68.75" x="388.5417" y="98.3276">BigQuery Client</text></g><!--MD5=[a72c47cdc6bb8f555d842274f043e0a4]
+entity producer1--><g id="elem_producer1"><rect fill="url(#gaxgshl64qhey2)" filter="url(#faxgshl64qhey)" height="52.0508" rx="4.1667" ry="4.1667" style="stroke:#9C27B0;stroke-width:1.0416666666666667;" width="109.375" x="18.2292" y="17.7083"/><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="67.7083" x="39.0625" y="42.8528">Producer 1</text><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="8.3333" lengthAdjust="spacing" textLength="54.1667" x="39.0625" y="53.536">Kafka Client</text></g><!--MD5=[3e34b956f241c65904223a8e6a5dfc9f]
+entity producer2--><g id="elem_producer2"><rect fill="url(#gaxgshl64qhey2)" filter="url(#faxgshl64qhey)" height="52.0508" rx="4.1667" ry="4.1667" style="stroke:#9C27B0;stroke-width:1.0416666666666667;" width="110.4167" x="17.7083" y="106.25"/><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="68.75" x="38.5417" y="131.3944">Producer 2</text><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="8.3333" lengthAdjust="spacing" textLength="54.1667" x="38.5417" y="142.0776">Kafka Client</text></g><!--MD5=[019f6774f902f72c488c9dcee70d4d6c]
+entity app1--><g id="elem_app1"><rect fill="url(#gaxgshl64qhey2)" filter="url(#faxgshl64qhey)" height="52.0508" rx="4.1667" ry="4.1667" style="stroke:#9C27B0;stroke-width:1.0416666666666667;" width="133.3333" x="382.2917" y="151.0417"/><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="12.5" lengthAdjust="spacing" textLength="91.6667" x="403.125" y="176.1861">Non-Kafka app</text><text fill="#FFFFFF" font-family="&quot;Verdana&quot;" font-size="8.3333" lengthAdjust="spacing" textLength="68.75" x="403.125" y="186.8693">BigQuery Client</text></g><!--MD5=[e749cf2317fe09cb1cfbe442f6f1e415]
+link producer1 to Kafka--><g id="link_producer1_Kafka"><path d="M127.7219,57.6771 C145.9375,62.3948 166.4229,67.701 185.2031,72.5667 " fill="none" id="producer1-to-Kafka" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="190.4521,73.926,182.4204,67.543,185.4099,72.6209,180.3321,75.6104,190.4521,73.926" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[9cd7ce266f494e629ef18eb3968d7d00]
+link producer2 to Kafka--><g id="link_producer2_Kafka"><path d="M128.1958,118.569 C146.3021,113.9877 166.6094,108.8499 185.2365,104.137 " fill="none" id="producer2-to-Kafka" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="190.4427,102.8198,180.3318,101.0814,185.3937,104.098,182.377,109.1598,190.4427,102.8198" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[828544d6cb4f83e58cf9b217020d9462]
+link Kafka to bq_sink--><g id="link_Kafka_bq_sink"><path d="M305.4396,88.5417 C323.0813,88.5417 342.9573,88.5417 362.1406,88.5417 " fill="none" id="Kafka-to-bq_sink" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="367.5302,88.5417,358.1552,84.375,362.3219,88.5417,358.1552,92.7083,367.5302,88.5417" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[f85bca38f3a21ae93f2ad7f07095331c]
+link bq_sink to BigQuery--><g id="link_bq_sink_BigQuery"><path d="M530.451,107.3427 C549.576,111.8122 569.5406,116.4777 587.1896,120.6022 " fill="none" id="bq_sink-to-BigQuery" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="592.5885,121.8641,584.4086,115.6721,587.517,120.6781,582.5111,123.7865,592.5885,121.8641" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[049702028a4f1d4e5ef92f6e3f42bde2]
+reverse link BigQuery to Metabase--><g id="link_BigQuery_Metabase"><path d="M698.5542,133.3333 C716.6542,133.3333 736.8063,133.3333 754.9906,133.3333 " fill="none" id="BigQuery-backto-Metabase" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="693.0073,133.3333,702.3823,137.5,698.2156,133.3333,702.3823,129.1667,693.0073,133.3333" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[18dda4f0a49ccb99df63f547a4dab1dd]
+link app1 to BigQuery--><g id="link_app1_BigQuery"><path d="M515.6927,162.0882 C539.0677,156.7526 565.1073,150.8089 587.4167,145.7166 " fill="none" id="app1-to-BigQuery" style="stroke:#2196F3;stroke-width:3.125;"/><polygon fill="#2196F3" points="592.7063,144.509,582.639,142.5334,587.6286,145.6682,584.4938,150.6577,592.7063,144.509" style="stroke:#2196F3;stroke-width:3.125;"/></g><!--MD5=[de5915d779c3e81ffbffedc8dbf0fea1]
+@startuml
+'https://plantuml.com/deployment-diagram
+!theme materia
+
+left to right direction
+
+cloud Metabase
+database BigQuery
+queue "Kafka Rapid" as Kafka
+
+card bq_sink [
+BigQuery sink river
+<size:8>BigQuery Client</size>
+]
+card producer1 [
+Producer 1
+<size:8>Kafka Client</size>
+]
+card producer2 [
+Producer 2
+<size:8>Kafka Client</size>
+]
+card app1 [
+Non-Kafka app
+<size:8>BigQuery Client</size>
+]
+
+
+producer1 - -> Kafka
+producer2 - -> Kafka
+Kafka - -> bq_sink
+bq_sink - -> BigQuery
+BigQuery <- - Metabase
+app1 - -> BigQuery
+@enduml
+
+@startuml
+
+
+
+skinparam backgroundColor transparent
+skinparam useBetaStyle false
+
+
+
+
+
+
+<style>
+  root {
+    BackgroundColor transparent
+    FontColor #FFF
+    HyperLinkColor #fd7e14
+    LineColor #1a78c2
+    LineThickness 1
+    Margin 10
+    Padding 6
+    Shadowing 0.0
+  }
+  node {
+   Padding 15
+   roundcorner 20
+   BackgroundColor #2196F3-#1a78c2
+  }
+  caption {
+    LineThickness 0
+  }
+  footer {
+    LineThickness 0
+  }
+  groupHeader {
+    BackgroundColor #fff
+    FontColor #9C27B0
+    FontStyle bold
+  }
+  header {
+    LineThickness 0
+  }
+  referenceHeader {
+    BackgroundColor transparent
+    FontColor #222
+    FontStyle bold
+  }
+  separator {
+    BackgroundColor #222
+    FontColor transparent
+    FontStyle bold
+  }
+  title {
+	FontSize 20
+	BorderRoundCorner            8
+	BorderThickness 	         1
+	BackgroundColor  #fff-#fff
+	FontColor #2196F3
+	BorderColor #fff
+  }
+  nwdiagDiagram {
+	network {
+			FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3    
+		LineColor #2196F3
+		LineThickness 1.0
+		FontColor #1a78c2
+	}
+	server {
+			FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	}
+	arrow {
+		FontColor #1a78c2
+		LineColor #1a78c2
+	}
+	group {
+		BackGroundColor #fff
+		LineColor $LIGHT_DARK
+		LineThickness 2.0
+		Margin 5
+		Padding 5
+	}
+  }
+  ganttDiagram {
+	task {
+			FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+		LineColor #2196F3
+		Margin 10
+		Padding 6
+	}
+	note {
+		FontColor #FFF
+		LineColor #7D1F8D
+		BackGroundColor #9C27B0
+	}
+	separator {
+		LineColor #fff
+		BackGroundColor #fff-#cccccc
+		FontColor #222
+	}
+	milestone {
+		FontColor #9C27B0
+		FontSize 16
+		FontStyle italic
+		BackGroundColor #fff
+		LineColor #cccccc
+	}
+	timeline {
+		BackgroundColor #fff
+		FontColor #222
+	}
+	closed {
+		BackgroundColor #CC7A00
+		FontColor #FFF
+	}
+  }
+</style>
+skinparam defaultFontName       "Verdana"
+skinparam defaultFontSize       12
+skinparam dpi                   100
+skinparam shadowing             true
+skinparam roundcorner           8
+skinparam ParticipantPadding    40
+skinparam BoxPadding            40
+skinparam Padding               10
+skinparam ArrowColor            #666
+skinparam stereotype {
+    CBackgroundColor #fff
+    CBorderColor #cccccc
+    ABackgroundColor #70bf73
+    ABorderColor #3D8C40
+    IBackgroundColor #B7161C
+    IBorderColor #b7161c
+    EBackgroundColor #ffad33
+    EBorderColor #CC7A00
+    NBackgroundColor #b052c0
+    NBorderColor #7D1F8D
+}
+skinparam title {
+	FontColor	                 #2196F3
+	BorderColor	                 #cccccc
+	FontSize	    	         20
+	BorderRoundCorner            8
+	BorderThickness 	         1
+	BackgroundColor              #fff-#fff
+}
+
+skinparam legend {
+	BackgroundColor #fff
+	BorderColor #cccccc
+	FontColor #222
+}
+
+skinparam swimlane {
+	BorderColor #9C27B0
+	BorderThickness 2
+	TitleBackgroundColor  #fff-#fff
+	TitleFontColor #2196F3
+}
+
+
+skinparam activity {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	BarColor #4CAF50
+	StartColor #9C27B0
+	EndColor #9C27B0
+	DiamondBackgroundColor #FFF-#fff
+  	DiamondBorderColor #cccccc
+	DiamondFontColor #222
+}
+
+
+skinparam participant {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	ParticipantBorderThickness 2
+}
+
+
+skinparam actor {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	FontColor #222
+}
+
+
+skinparam arrow {
+	Thickness 3
+	Color #2196F3
+	FontColor #222
+}
+
+
+skinparam sequence {
+	BorderColor #2196F3
+	TitleFontColor #2196F3
+	BackgroundColor transparent
+	StartColor #2196F3
+	EndColor #2196F3
+	BoxBackgroundColor #fff
+	BoxBorderColor #666
+	BoxFontColor #222
+	DelayFontColor #222
+	LifeLineBorderColor #cccccc
+	LifeLineBorderThickness 2
+	LifeLineBackgroundColor #fff
+	GroupBorderColor #666
+	GroupFontColor #222
+	GroupHeaderFontColor #9C27B0
+	DividerBackgroundColor #FFF-#fff
+    DividerBorderColor #666
+    DividerBorderThickness 2
+    DividerFontColor #222
+	ReferenceBackgroundColor transparent
+	ReferenceBorderColor #666
+	ReferenceFontColor #222
+	ReferenceHeaderFontColor #9C27B0
+	StereotypeFontColor #FFF
+}
+
+
+skinparam partition {
+	BorderColor #2196F3
+	FontColor #2196F3
+	BackgroundColor transparent
+}
+
+
+skinparam collections {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+}
+
+
+skinparam control {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	FontColor #222
+}
+
+
+skinparam entity {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	FontColor #222
+}
+
+
+skinparam boundary {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	FontColor #222
+}
+
+
+skinparam agent {
+	BackgroundColor #orange
+	BorderColor #999999
+	FontColor #333333
+}
+
+
+skinparam note {
+	BorderThickness 1
+	BackgroundColor #b052c0-#9C27B0
+	BorderColor #9C27B0
+	FontColor #FFF
+}
+
+
+skinparam artifact {
+	BackgroundColor #FFF-#fff
+	BorderColor #666
+	FontColor #666
+}
+
+
+skinparam component {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+}
+
+
+skinparam interface {
+	BackgroundColor  #B7161C
+	BorderColor  #e51c23
+	FontColor #222
+}
+
+
+skinparam storage {
+	BackgroundColor #ffad33-#ff9800
+  	BorderColor #ff9800
+	FontColor #FFF
+}
+
+
+skinparam node {
+	BackgroundColor #fff-#fff
+	BorderColor #222
+	FontColor #222
+}
+
+
+skinparam cloud {
+	BackgroundColor #F2FCFE-#eeeeee
+	BorderColor #F2FCFE
+	FontColor #222
+}
+
+
+skinparam database {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	FontColor #222
+}
+
+
+skinparam class {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	HeaderBackgroundColor #2196F3-#1a78c2
+	StereotypeFontColor #222
+	BorderThickness 1
+	AttributeFontColor #fff
+	AttributeFontSize 11
+}
+
+
+skinparam object {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	StereotypeFontColor #222
+	BorderThickness 1
+	AttributeFontColor #222
+	AttributeFontSize 11
+}
+
+
+skinparam usecase {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	BorderThickness 2
+	StereotypeFontColor #2196F3
+}
+
+
+skinparam rectangle {
+	FontColor #2196F3
+	BackgroundColor #fff-#fff
+	BorderThickness 2
+	StereotypeFontColor #2196F3
+}
+
+
+skinparam package {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	BackgroundColor #fff-#fff
+	BorderThickness 2
+}
+
+
+skinparam folder {
+	BackgroundColor #FFF-#fff
+  	BorderColor #ff9800
+	FontColor #ff9800
+	BorderThickness 2
+}
+
+
+skinparam frame {
+	BackgroundColor #FFF-#fff
+  	BorderColor #9C27B0
+	FontColor #9C27B0
+	BorderThickness 2
+}
+
+
+skinparam state {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+	BorderColor #1a78c2
+	StartColor #9C27B0
+	EndColor #9C27B0
+	AttributeFontColor #222
+	AttributeFontSize 11
+}
+
+
+skinparam queue {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+}
+
+
+skinparam card {
+	BackgroundColor #b052c0-#9C27B0
+	BorderColor #9C27B0
+	FontColor #FFF
+}
+
+
+skinparam file {
+	BackgroundColor #fff-#fff
+	BorderColor #666
+	FontColor #666
+
+}
+
+
+skinparam stack {
+		FontColor #FFF
+	BorderColor #2196F3
+	BackgroundColor #4dabf5-#2196F3
+}
+
+left to right direction
+
+cloud Metabase
+database BigQuery
+queue "Kafka Rapid" as Kafka
+
+card bq_sink [
+BigQuery sink river
+<size:8>BigQuery Client</size>
+]
+card producer1 [
+Producer 1
+<size:8>Kafka Client</size>
+]
+card producer2 [
+Producer 2
+<size:8>Kafka Client</size>
+]
+card app1 [
+Non-Kafka app
+<size:8>BigQuery Client</size>
+]
+
+
+producer1 - -> Kafka
+producer2 - -> Kafka
+Kafka - -> bq_sink
+bq_sink - -> BigQuery
+BigQuery <- - Metabase
+app1 - -> BigQuery
+@enduml
+
+PlantUML version 1.2022.2beta11(Unknown compile time)
+(GPL source distribution)
+Java Runtime: Java(TM) SE Runtime Environment
+JVM: Java HotSpot(TM) 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: US
+--></g></svg>

--- a/docs/diagrams/src/persistence/bigquery-metabase.puml
+++ b/docs/diagrams/src/persistence/bigquery-metabase.puml
@@ -1,0 +1,36 @@
+@startuml
+'https://plantuml.com/deployment-diagram
+!theme materia
+
+left to right direction
+
+cloud Metabase
+database BigQuery
+queue "Kafka Rapid" as Kafka
+
+card bq_sink [
+    BigQuery sink river
+    <size:8>BigQuery Client</size>
+]
+card producer1 [
+    Producer 1
+    <size:8>Kafka Client</size>
+]
+card producer2 [
+    Producer 2
+    <size:8>Kafka Client</size>
+]
+card app1 [
+    Non-Kafka app
+    <size:8>BigQuery Client</size>
+]
+
+
+producer1 --> Kafka
+producer2 --> Kafka
+Kafka --> bq_sink
+bq_sink --> BigQuery
+BigQuery <-- Metabase
+app1 --> BigQuery
+
+@enduml

--- a/docs/persistence/influxdb.md
+++ b/docs/persistence/influxdb.md
@@ -1,13 +1,22 @@
-# Influxdb
+# InfluxDB
 
 !!! info "Aiven discontinues InfluxDB"
-    Aiven has informed us that they will discontinue support for InfluxDB. The timeline is yet to be confirmed, but could be as early as end-of-year 2022. Talk to us in NAIS before starting to use InfluxDB
+    Aiven has informed us that they will discontinue support for InfluxDB. 
+    The timeline is yet to be confirmed, but could be as early as end-of-year 2022. 
+    We recommend that teams using InfluxDB today find other alternatives suitable for their use case.
 
-The NAIS platform offers Influxdb via [Aiven](https://aiven.io/). A typical use case is to store metrics from your app and visualize them in [Grafana](https://grafana.adeo.no/).
+## Suggested alternative
 
-## Get your own instance
-As there are many teams that need Influxdb we use an IaC-repo to provision each instance.
-Head over to [aiven-iac](https://github.com/navikt/aiven-iac#influxdb).
+Team Digihot has spent some time piloting a concept that uses BigQuery and Metabase as a replacement for InfluxDB and Grafana.
+They are very satisfied with the solution, and we have concluded that this is a viable replacement going forward.
+In their case, all applications that sent data to InfluxDB also used Kafka, so their solution is based around Kafka.
+Depending on the situation and use case, it would also be possible to send data to BigQuery directly from the applications.
+
+Once the data is in BigQuery, you can use Metabase to create dashboards or dataproducts.
+
+![diagram of solution](../diagrams/out/persistence/bigquery-metabase.svg)
+
+## Reference documentation for existing instances of InfluxDB
 
 ### Username and password
 For now we are manually distributing the username and password for each instance.
@@ -23,18 +32,18 @@ The default database is created with a default retention policy of 30 days. You 
 create retention policy "365d" on "defaultdb" duration 365d replication 1 shard duration 1w default
 ```
 
-## Datasource in grafana.adeo.no
+### Datasource in grafana.adeo.no
 Let us know in [#pig-aiven](https://nav-it.slack.com/archives/C018L1JATBQ) if you want your Influxdb to be exposed at grafana.adeo.no.
 This means that everyone can access your data.
 
-## Access from Nais-app
+### Access from Nais-app
 If you need access from an application, you need to specify Inluxdb instance.
 See [nais.yaml-reference](../nais-application/application.md#influxinstance).
 
-### Loading CA-certificate
+#### Loading CA-certificate
 Your application will also need an CA-certificate for your app to be able to connect to Aiven with SSL. The certificate will be loaded into your pod as an environment variable if you define a [`.spec.kafka.pool`](../nais-application/application.md#kafkapool) in your nais.yaml file.
 
-## Access from laptop
+### Access from laptop
 With Naisdevice you have access to the _aiven-prod_ gateway.
 This is a JITA (just in time access) gateway, so you need to describe why, but the access is automatically given.
 
@@ -43,5 +52,6 @@ influx -username avnadmin -password foo -host influx-instancename-nav-dev.aivenc
 ```
 
 PS: Remember to use Influxdb CLI pre v2. For example v1.8.3.
-## Support
+
+### Support
 We do not offer support on Influxdb as software, but questions about Aiven and provisioning can be directed to [#pig_aiven](https://nav-it.slack.com/archives/C018L1JATBQ) on Slack.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,9 @@ extra_css:
   - material_theme_stylesheet_overrides/uu.css
 plugins:
   - search
+  - build_plantuml:
+      output_format: "svg"
+      input_extensions: "puml"
 markdown_extensions:
   - toc:
       permalink: True

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "httplib2"
+version = "0.20.4"
+description = "A comprehensive HTTP client library."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
+
+[[package]]
 name = "importlib-metadata"
 version = "3.3.0"
 description = "Read metadata from Python packages"
@@ -120,6 +131,18 @@ PyYAML = ">=3.10"
 tornado = ">=5.0"
 
 [[package]]
+name = "mkdocs-build-plantuml-plugin"
+version = "1.6.0"
+description = "An MkDocs plugin to call plantuml locally or remote"
+category = "main"
+optional = false
+python-versions = ">=3.2"
+
+[package.dependencies]
+httplib2 = "*"
+mkdocs = ">=1.0.4"
+
+[[package]]
 name = "mkdocs-material"
 version = "6.1.7"
 description = "A Material Design theme for MkDocs"
@@ -187,6 +210,17 @@ python-versions = ">=3.5"
 Markdown = ">=3.2"
 
 [[package]]
+name = "pyparsing"
+version = "3.0.7"
+description = "Python parsing module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
 name = "pyyaml"
 version = "5.3.1"
 description = "YAML parser and emitter for Python"
@@ -252,7 +286,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "71534e385b2f8aa4d166f395b80ef2a33777ed8503393f8cfcd09131af832a5a"
+content-hash = "c12bd6dc59bb90fd32d3d55e12c57980f5e19999641d649005f7648cbba4d80c"
 
 [metadata.files]
 click = [
@@ -261,6 +295,10 @@ click = [
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+httplib2 = [
+    {file = "httplib2-0.20.4-py3-none-any.whl", hash = "sha256:8b6a905cb1c79eefd03f8669fd993c36dc341f7c558f056cb5a33b5c2f458543"},
+    {file = "httplib2-0.20.4.tar.gz", hash = "sha256:58a98e45b4b1a48273073f905d2961666ecf0fbac4250ea5b47aef259eb5c585"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-3.3.0-py3-none-any.whl", hash = "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"},
@@ -304,25 +342,47 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mkdocs = [
     {file = "mkdocs-1.1.2-py3-none-any.whl", hash = "sha256:096f52ff52c02c7e90332d2e53da862fde5c062086e1b5356a6e392d5d60f5e9"},
     {file = "mkdocs-1.1.2.tar.gz", hash = "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"},
+]
+mkdocs-build-plantuml-plugin = [
+    {file = "mkdocs-build-plantuml-plugin-1.6.0.tar.gz", hash = "sha256:7b09261b223578f07325509d1c4fb9fd7fe422769f93ffddf3111ed6055dcbcc"},
 ]
 mkdocs-material = [
     {file = "mkdocs-material-6.1.7.tar.gz", hash = "sha256:44e28f5f4ac3728c80fc9831cbda428e807b6b38473130acc45da6e62ce7f866"},
@@ -343,6 +403,10 @@ pymdown-extensions = [
     {file = "pymdown-extensions-8.0.1.tar.gz", hash = "sha256:9ba704052d4bdc04a7cd63f7db4ef6add73bafcef22c0cf6b2e3386cf4ece51e"},
     {file = "pymdown_extensions-8.0.1-py2.py3-none-any.whl", hash = "sha256:a3689c04f4cbddacd9d569425c571ae07e2673cc4df63a26cdbf1abc15229137"},
 ]
+pyparsing = [
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
     {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
@@ -354,6 +418,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ mkdocs = "^1.1.2"
 Pygments = "^2.7.2"
 pymdown-extensions = "^8.0.1"
 mkdocs-material = "^6.1.4"
+mkdocs-build-plantuml-plugin = "^1.6.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Also added mkdocs plugin that generates PlantUML diagrams. Any diagram under `docs/diagrams/src` will be generated on serve.

Probably best practice to run serve locally while editing, and commiting the generated file along with the puml-file changes, but it will always try to generate a new file if source is changed.