### PR TITLE
Unreachable link to Aiven article

### DIFF
--- a/docs/persistence/kafka/offsets.md
+++ b/docs/persistence/kafka/offsets.md
@@ -127,4 +127,4 @@ You can use this query to get offsets for a consumer group:
 [offset-management]: https://docs.confluent.io/platform/current/clients/consumer.html#offset-management
 [rebalance]: https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#rebalancecallback
 [seek]: https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#seek(org.apache.kafka.common.TopicPartition,long)
-[aiven-offset-help]: https://help.aiven.io/en/articles/2661525-viewing-and-resetting-consumer-group-offsets
+[aiven-offset-help]: https://developer.aiven.io/docs/products/kafka/howto/viewing-resetting-offset


### PR DESCRIPTION
This link fails: https://help.aiven.io/en/articles/2661525-viewing-and-resetting-consumer-group-offsets
I believe this is the correct one
https://developer.aiven.io/docs/products/kafka/howto/viewing-resetting-offset