### PR TITLE
These is no name argument; updating adhoc job syntax

### DIFF
--- a/docs/naisjob/README.md
+++ b/docs/naisjob/README.md
@@ -136,5 +136,5 @@ You can look at what Ginuudan has done to complete your Naisjob by running `kube
     Run the following command to create a ad-hoc job based on your cronjob:
 
     ```shell
-    kubectl create job --name=<newname> --from=cronjobs/<naisjobname>
+    kubectl create job --namespace=<mynamespace> --from=cronjobs/<naisjobname> <newname>
     ```


### PR DESCRIPTION
There is no `name` argument, kubectl gives an error message when using the suggested syntax: `Error: unknown flag: --name`