### PR TITLE
ttlSecondsAfterFinished is now available in gcp

### DIFF
--- a/docs/naisjob/reference.md
+++ b/docs/naisjob/reference.md
@@ -3999,7 +3999,6 @@ Specify the number of seconds to wait before removing the Job after it has finis
 
 Type: `integer`<br />
 Required: `false`<br />
-Availability: on-premises<br />
 
 ??? example
     ``` yaml


### PR DESCRIPTION
`ttlSecondsAfterFinished` was previously enabled through the ttl-controller alpha, which was only enabled on-premise. Since k8s 1.21, it has been moved to beta and is enabled by default, which makes it available for general use in our gcp clusters.