### PR TITLE
Added mention of Oracle DEV and inlined Postgres howto

### DIFF
--- a/docs/device/services.md
+++ b/docs/device/services.md
@@ -9,7 +9,7 @@ This document describes the different services you will get access to through na
 * [basta](https://basta.adeo.no)
 * [vault](https://vault.adeo.no)
 * [fasit](https://fasit.adeo.no)
-* [vera](https://vera.adeo.no)
+* [vera](https://vera.intern.nav.no)
 * [nexus/repo.adeo.no](https://repo.adeo.no)
 * [bitbucket/stash](https://stash.adeo.no)
 * [minwintid](https://minwintidmobil.adeo.no/minwintid)
@@ -18,4 +18,32 @@ This document describes the different services you will get access to through na
 * VDI/Utviklerimage \(Use horizon.nav.no as connection server\)
 * [Microsoft Teams](https://teams.microsoft.com/)
 * [Microsoft Sharepoint/Navet](https://navno.sharepoint.com/)
-* Postgres ([join this team to get access](https://teams.microsoft.com/l/team/19%3ab9d12407248e489589a71464f7265d9f%40thread.tacv2/conversations?groupId=a6816684-aced-43be-8791-451f18a266c5&tenantId=62366534-1ec3-4962-8869-9b5535279d0b), [howto](https://nav-it.slack.com/archives/C010WR3ALNR/p1611051372002600))
+* Postgres ([join this team to get access](https://account.activedirectory.windowsazure.com/r#/manageMembership?objectType=Group&objectId=a6816684-aced-43be-8791-451f18a266c5), [howto](#how-to-use-postgres-via-naisdevice))
+* Oracle DEV ([join this team to get access](https://account.activedirectory.windowsazure.com/r#/manageMembership?objectType=Group&objectId=d45ad78e-6cb7-44a4-821b-db6f432da9e5))
+
+
+## How to use Postgres via naisdevice
+
+See also the Slack channel [#postgres-på-laptop](https://nav-it.slack.com/archives/C010WR3ALNR)
+
+### Before connecting to Postgres
+
+A few things need to be in place before you can connect.
+
+* You must be a member of the `postgres-fra-laptop` [AD group](https://account.activedirectory.windowsazure.com/r#/manageMembership?objectType=Group&objectId=a6816684-aced-43be-8791-451f18a266c5).
+* You need to perform a risk assessment (ROS).
+* Whitelist your database for use with naisdevice in [database-iac](https://github.com/navikt/database-iac) by adding the following to the database entry:
+    ```yaml
+    naisdevice:
+      enabled: true
+      ros: <link to ROS>
+    ```
+
+### Connecting to Postgres from your laptop
+
+1. Connect to the relevant naisdevice gateway:
+    * dev: postgres-dev (automatically connected)
+    * prod: postgres-prod (requires JITA)
+2. Connect to the special naisdevice hostnames (these are only for use with naisdevice):
+   * dev: dev-pg.intern.nav.no
+   * prod: prod-pg.intern.nav.no


### PR DESCRIPTION
Previously the Postgres howto was a link to Slack, which eventually will expire. Makes more sense to "inline" it in the documentation and also clean it up a bit.