### PR TITLE
Disable line numbers for better accessibility

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ markdown_extensions:
                 format: !!python/name:pymdownx.superfences.fence_code_format
     - pymdownx.highlight:
           use_pygments: true
-          linenums: true
+          linenums: false
           linenums_style: pymdownx-inline
           anchor_linenums: true
     - pymdownx.inlinehilite


### PR DESCRIPTION
Disable line number in code highlight for better accessibility.

## Errors
Empty link

## What It Means
A link contains no text.

## Why It Matters
If a link contains no text, the function or purpose of the link will not be presented to the user. This can introduce confusion for keyboard and screen reader users.

## How to Fix It
Remove the empty link or provide text within the link that describes the functionality and/or target of that link.

## The Algorithm... in English
An anchor element has an href attribute, but contains no text (or only spaces) and no images with alternative text.

## Standards and Guidelines

* [2.4.4 Link Purpose (In Context) (Level A)](https://webaim.org/standards/wcag/checklist#sc2.4.4)

![Screenshot 2022-12-02 at 09 57 29](https://user-images.githubusercontent.com/968267/205254838-7bd312ba-5699-4878-b92f-16c2f1e1d437.png)
