### PR TITLE
azure-ad: clarify group ID uniqueness in different tenants

### DIFF
--- a/docs/security/auth/azure-ad/configuration.md
+++ b/docs/security/auth/azure-ad/configuration.md
@@ -201,9 +201,12 @@ spec:
 
 !!! warning
 
-    **Ensure that the object ID for the group is valid, and that the group actually exists in Azure AD.**
+    **Ensure that the object ID for the group actually exists in Azure AD for your environment.**
 
-    Non-existing groups will be skipped.
+    Beware that the AAD tenant for dev is not the same as for prod, so even if both contain the same group name there may be two different object IDs.
+    
+    Non-existing groups (object IDs) will be skipped.
+    
 
 Now all user tokens acquired for your application will include the `groups` claim.
 


### PR DESCRIPTION
fordi jeg brukte lang tid på å finne ut av dette selv. Forsto ikke hva som som var galt (i dev) med den object ID jeg hadde hentet ut fra AAD (i prod).

Burde kanskje dokumentasjonen si noe om hvor man går for å finne object ID for henholdsvis dev og prod? Jeg ble tipset om å gå hit https://developer.microsoft.com/en-us/graph/graph-explorer og logge på med en testbruker jeg hadde opprettet i [IDA](https://ida.intern.nav.no/).