### PR TITLE
Add instructions for debugging/installing missing gcloud plugin

### DIFF
--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -89,6 +89,12 @@ Kubernetes master is running at https://127.0.0.1:14131
 ...
 ```
 
+If you get an error message from `cluster-info` you might need to install "gke-gcloud-auth-plugin" as well.  
+
+```bash
+gcloud components install gke-gcloud-auth-plugin
+```
+
 ### On-premise
 
 When connecting to on-premise clusters, you need to authenticate with Azure AD.

--- a/docs/basics/access.md
+++ b/docs/basics/access.md
@@ -78,21 +78,27 @@ Once installed, you need to authenticate with Google using your NAV e-mail.
 $ gcloud auth login
 ```
 
-Make sure you are connected to the right cluster, and verify that it works.
+You will also need to install a plugin in order to authenticate to the Kubernetes clusters:
+
+```bash
+$ gcloud components install gke-gcloud-auth-plugin
+```
+
+Then, select a cluster:
 
 ```bash
 $ kubectl config use-context prod-gcp
+
 Switched to context "prod-gcp".
-$ kubectl cluster-info
-gcp-terraform $ k cluster-info
-Kubernetes master is running at https://127.0.0.1:14131
-...
 ```
 
-If you get an error message from `cluster-info` you might need to install "gke-gcloud-auth-plugin" as well.  
+And verify that you're connected:
 
 ```bash
-gcloud components install gke-gcloud-auth-plugin
+$ kubectl cluster-info
+
+Kubernetes control plane is running at https://[...]
+...
 ```
 
 ### On-premise


### PR DESCRIPTION
Legg inn hint om debugging for dei som får feilmelding frå "cluster-info" ved installasjon av kubectl. 

Feilmeldinga ein får frå "cluster-info" skildrar eigentleg veldig godt at ein manglar "gke-gcloud-auth-plugin", men både eg og andre på teamet feilsøka ei stund før vi innsåg at vi kanskje heller burde lese heile feilmeldinga enn å google strofar frå den. 

Tenker det er fint å ha med eit "om dette ikkje fungerer"-notat i rettleiinga for installasjon av kubectl også, for oss som les den meir nøye enn output frå konsoll. Det er dessutan tryggjande å få bekrefta at det er eit kjend problem når ting ikkje fungerer som venta.




[Opphavleg spørsmål/forklaring av problemet på slack ](https://nav-it.slack.com/archives/C5KUST8N6/p1681373043321849)