### PR TITLE
legg til default host

### DIFF
--- a/docs/nais-application/access-policy.md
+++ b/docs/nais-application/access-policy.md
@@ -250,6 +250,7 @@ Default hosts that are added and accessible for every application:
 | `metadata.google.internal`  | 80   | TCP       |
 | `private.googleapis.com`    | 443  | TCP       |
 | `login.microsoftonline.com` | 443  | TCP       |
+| `graph.microsoft.com`       | 443  | TCP       |
 | `oidc.difi.no`              | 443  | TCP       |
 | `ver2.maskinporten.no`      | 443  | TCP       |
 | `maskinporten.no`           | 443  | TCP       |


### PR DESCRIPTION
Ser ikke ms-graph dokumentert her (selv om det står andre steder i doc'en https://docs.nais.io/security/auth/azure-ad/configuration/?h=graph.mic#google-cloud-platform-gcp)