### PR TITLE
Make repo public in guide

### DIFF
--- a/docs/guides/basics.md
+++ b/docs/guides/basics.md
@@ -88,7 +88,7 @@ For programming related code you have the option to choose between different lan
 Create a new repository on GitHub. This will be the home of your application.
 
 ```bash
-gh repo create navikt/<my-repo> --add-readme --public --clone
+gh repo create navikt/<my-repo> --add-readme --public --clone --public
 ```
 
 For your new repository add the following secret:


### PR DESCRIPTION
The command to create a new repo is missing visibility:
https://docs.nais.io/guides/basics/#step-1-create-a-new-repository

Maybe also there should be a reference to the NAV guidelines about public repos.