### PR TITLE
Update install instructions to use GAR for nais-ppa

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -35,11 +35,12 @@ If you are unable to run nais after installing, check out our [troubleshooting g
 
 1. Add the nais PPA repo:
     ``` 
-    NAIS_GPG_KEY="/usr/share/keyrings/nav_nais.gpg"
-    curl -sfSL "https://ppa.nais.io/KEY.gpg" | gpg --dearmor | sudo dd of="$NAIS_GPG_KEY"
-    echo "deb [signed-by=$NAIS_GPG_KEY] https://ppa.nais.io/ ./" | sudo tee /etc/apt/sources.list.d/nav_nais.list
-    sudo apt update # Now you can apt install nais
+    NAIS_GPG_KEY="/etc/apt/keyrings/nav_nais_gar.gpg"
+    curl -sfSL "https://europe-north1-apt.pkg.dev/doc/repo-signing-key.gpg" | sudo dd of="$NAIS_GPG_KEY"
+    echo "deb [signed-by=$NAIS_GPG_KEY] https://europe-north1-apt.pkg.dev/projects/nais-io nais-ppa main" | sudo tee /etc/apt/sources.list.d/nav_nais_gar.list
+    sudo apt update
     ```
+   
 2. Install the nais package:
     ```
     sudo apt install nais

--- a/docs/device/install-tenant.md
+++ b/docs/device/install-tenant.md
@@ -70,11 +70,11 @@
 
 1. Add the nais PPA repo:
 
-   ```
-   NAIS_GPG_KEY="/usr/share/keyrings/nav_nais.gpg"
-   curl -sfSL "https://ppa.nais.io/KEY.gpg" | gpg --dearmor | sudo dd of="$NAIS_GPG_KEY"
-   echo "deb [signed-by=$NAIS_GPG_KEY] https://ppa.nais.io/ ./" | sudo tee /etc/apt/sources.list.d/nav_nais.list
-   sudo apt update # Now you can apt install naisdevice
+   ``` 
+   NAIS_GPG_KEY="/etc/apt/keyrings/nav_nais_gar.gpg"
+   curl -sfSL "https://europe-north1-apt.pkg.dev/doc/repo-signing-key.gpg" | sudo dd of="$NAIS_GPG_KEY"
+   echo "deb [signed-by=$NAIS_GPG_KEY] https://europe-north1-apt.pkg.dev/projects/nais-io nais-ppa main" | sudo tee /etc/apt/sources.list.d/nav_nais_gar.list
+   sudo apt update
    ```
 
    **NOTE** curl is not installed in a "fresh" ubuntu:

--- a/docs/device/install.md
+++ b/docs/device/install.md
@@ -89,12 +89,14 @@
 1. [Install Kolide agent](install.md#install-kolide-agent).
 2. Add the nais PPA repo:
     ``` 
-    NAIS_GPG_KEY="/usr/share/keyrings/nav_nais.gpg"
-    curl -sfSL "https://ppa.nais.io/KEY.gpg" | gpg --dearmor | sudo dd of="$NAIS_GPG_KEY"
-    echo "deb [signed-by=$NAIS_GPG_KEY] https://ppa.nais.io/ ./" | sudo tee /etc/apt/sources.list.d/nav_nais.list
-    sudo apt update # Now you can apt install naisdevice
+    NAIS_GPG_KEY="/etc/apt/keyrings/nav_nais_gar.gpg"
+    curl -sfSL "https://europe-north1-apt.pkg.dev/doc/repo-signing-key.gpg" | sudo dd of="$NAIS_GPG_KEY"
+    echo "deb [signed-by=$NAIS_GPG_KEY] https://europe-north1-apt.pkg.dev/projects/nais-io nais-ppa main" | sudo tee /etc/apt/sources.list.d/nav_nais_gar.list
+    sudo apt update
     ```
+
     **NOTE**  curl is not installed in a "fresh" ubuntu:
+   
     ```
     sudo apt install curl
     ``` 


### PR DESCRIPTION
Moved the key to `/etc/apt/keyrings`, because of this line in `man sources.list`:

> The recommended locations for keyrings are /usr/share/keyrings for keyrings managed by packages, and /etc/apt/keyrings for keyrings managed by the system operator.
