### PR TITLE
updated device ownership

### DIFF
--- a/docs/device/install.md
+++ b/docs/device/install.md
@@ -194,7 +194,7 @@ This means that there are some do's and don'ts. You have to agree to the followi
 
 #### Don't
 
-- enroll anything other than NAV owned devices.
+- enroll devices that are privatly owned.
 - share your device with others. A naisdevice is a personal device.
 - turn on sshd or similar services on your device.
 - set up your device as a proxy. For anything!


### PR DESCRIPTION
Nå som konsulentmaskiner skal ut av `"Pilot"` så har det vært klager på denne. Nå matcher den de faktiske D&Dene på eierskap.