### PR TITLE
Bruk -- ved kubectl exec

### DIFF
--- a/docs/clusters/migrating-databases-to-gcp.md
+++ b/docs/clusters/migrating-databases-to-gcp.md
@@ -66,7 +66,7 @@ kubectl apply -f https://raw.githubusercontent.com/navikt/gcp-migrering/main/gcl
 `exec` into that pod
 
 ```shell
-kubectl exec -it gcloud /bin/bash
+kubectl exec -it gcloud -- /bin/bash
 ```
 
 Log in to gcloud with your own NAV-account


### PR DESCRIPTION
```
❯ kubectl exec -it gcloud /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
```