### PR TITLE
Add tags overview page

### DIFF
--- a/docs/reference/tags.md
+++ b/docs/reference/tags.md
@@ -1,0 +1,3 @@
+# Tags
+
+<!-- material/tags -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,7 +68,8 @@ extra_css:
   - material_theme_stylesheet_overrides/grid.css
 plugins:
   - awesome-pages
-  - tags
+  - tags:
+      tags_file: reference/tags.md
   - macros:
       j2_variable_start_string: "<<"
       j2_variable_end_string: ">>"


### PR DESCRIPTION
This will make all tags clickable, and they will open the tags overview with an anchor to the given tag.

![image](https://github.com/nais/doc/assets/85170275/3c829c17-3714-4432-bdd1-d2eb64a392d2)
