### PR TITLE
Info om blokkerte suffiks for nav.no i prod-gcp

### DIFF
--- a/tenants/nav/reference/environments.md
+++ b/tenants/nav/reference/environments.md
@@ -30,11 +30,11 @@ See [explanation for exposing application](../explanation/exposing-application.m
 
 #### Ingress domains
 
-| domain | accessible from |
-| :--- | :--- |
-| nav.no | Internet |
-| intern.nav.no  | NAV internal networks (including [naisdevice](../explanation/naisdevice.md))| 
-| ansatt.nav.no  | Internet, but only accessible by authenticated humans on compliant devices | 
+| domain | accessible from                                                                 |
+| :--- |:--------------------------------------------------------------------------------|
+| nav.no | Internet(URLs containing /metrics, /actuator or /internal are blocked by BIGIP) |
+| intern.nav.no  | NAV internal networks (including [naisdevice](../explanation/naisdevice.md))    | 
+| ansatt.nav.no  | Internet, but only accessible by authenticated humans on compliant devices      | 
 
 See [explanation for exposing application](../explanation/exposing-application.md) for more information.
 

--- a/tenants/nav/reference/environments.md
+++ b/tenants/nav/reference/environments.md
@@ -32,7 +32,7 @@ See [explanation for exposing application](../explanation/exposing-application.m
 
 | domain | accessible from                                                                 |
 | :--- |:--------------------------------------------------------------------------------|
-| nav.no | Internet(URLs containing /metrics, /actuator or /internal are blocked by BIGIP) |
+| nav.no | Internet(URLs containing /metrics, /actuator or /internal are blocked by Cloud Armor) |
 | intern.nav.no  | NAV internal networks (including [naisdevice](../explanation/naisdevice.md))    | 
 | ansatt.nav.no  | Internet, but only accessible by authenticated humans on compliant devices      | 
 


### PR DESCRIPTION
Slet litt med å finne info om dette i docen og det har vært der tidligere. ref https://nav-it.slack.com/archives/CCSET7820/p1685536563209559