### PR TITLE
Documenting manual client certification deletion for Postgres

### DIFF
--- a/docs/persistence/postgres/how-to/certification-sync-issues.md
+++ b/docs/persistence/postgres/how-to/certification-sync-issues.md
@@ -4,13 +4,19 @@ tags: [postgres, certificate, how-to]
 ---
 
 If you have deleted your application and recreate it, there might be an issue that your new app will not be able to create a client certificate because the old one still exists.
-Your deploy may fail with errormessages like 
+Your deploy may fail with an error message such as the one below:
 
-`MountVolume.SetUp failed for volume "sqeletor-sql-ssl-cert" : secret "sqeletor-<podname>" not found`.
+```
+MountVolume.SetUp failed for volume "sqeletor-sql-ssl-cert" : secret "sqeletor-<podname>" not found
+```
 
-To delete the database client credentials for your application, you may navigate to SQL -> <your_instance> -> Connections -> Security in Cloud Console and delete your certificate there, or you may
+To delete the database client credentials for your application, in Google Cloud Console navigate to [Cloud SQL instances](https://console.cloud.google.com/sql/instances) -> <your_instance> -> Connections -> Security, and then scroll down to _Manage client certificates_ and delete your certificate there.
+
+This can also be done using the `gcloud`-cli.
 
 ```bash
 $ gcloud sql ssl client-certs delete COMMON_NAME --instance=INSTANCE
 ```
-COMMON_NAME is usually equal to INSTANCE usually equal to application name.
+
+_COMMON_NAME_ is usually equal to _INSTANCE_, which is usually equal to application name.
+Run `kubectl describe sqlsslcert <certificate>` to find _COMMON_NAME_ and _INSTANCE_ for one specific certificate.

--- a/docs/persistence/postgres/how-to/certification-sync-issues.md
+++ b/docs/persistence/postgres/how-to/certification-sync-issues.md
@@ -1,0 +1,16 @@
+---
+title: Delete database client certificate
+tags: [postgres, certificate, how-to]
+---
+
+If you have deleted your application and recreate it, there might be an issue that your new app will not be able to create a client certificate because the old one still exists.
+Your deploy may fail with errormessages like 
+
+`MountVolume.SetUp failed for volume "sqeletor-sql-ssl-cert" : secret "sqeletor-<podname>" not found`.
+
+To delete the database client credentials for your application, you may navigate to SQL -> <your_instance> -> Connections -> Security in Cloud Console and delete your certificate there, or you may
+
+```bash
+$ gcloud sql ssl client-certs delete COMMON_NAME --instance=INSTANCE
+```
+COMMON_NAME is usually equal to INSTANCE usually equal to application name.


### PR DESCRIPTION
Documenting manual client certification deletion for Postgres, in case of errors like https://nav-it.slack.com/archives/C5KUST8N6/p1716883403108279?thread_ts=1716882709.704449&cid=C5KUST8N6