### PR TITLE
Correct tenant-specific update and uninstall instructions

### DIFF
--- a/docs/operate/naisdevice/how-to/install.md
+++ b/docs/operate/naisdevice/how-to/install.md
@@ -67,9 +67,7 @@ tags: [naisdevice, how-to]
     1. Use `<Command> + <Space>` to find your `naisdevice.app` and press `<Enter>`.
     1. Follow the [instructions to connect your _nais_ device](#connect-naisdevice-through-tasksys-tray-icon).
 
-=== "Windows"
-
-    #### Install using Scoop
+=== "Windows (Scoop)"
 
     {% if tenant() == "nav" %}
 
@@ -106,7 +104,7 @@ tags: [naisdevice, how-to]
     (you will be asked for administrator access to run the installer)
     1. Start _naisdevice_ from the _Start menu_
 
-=== "Manual"
+=== "Winows (Manual)"
 
     {% if tenant() == "nav" %}
 

--- a/docs/operate/naisdevice/how-to/uninstall.md
+++ b/docs/operate/naisdevice/how-to/uninstall.md
@@ -4,59 +4,62 @@ tags: [naisdevice, how-to]
 
 # Uninstall naisdevice
 
-## OS-specific Uninstall steps
-
 {% if tenant() == "nav" %}
 
-### macOS uninstall
+## OS-specific Uninstall steps
 
-1. Stop and remove Kolide and the related launch mechanisms
-    ```zsh
-    sudo /bin/launchctl unload /Library/LaunchDaemons/com.kolide-k2.launcher.plist
-    sudo /bin/rm -f /Library/LaunchDaemons/com.kolide-k2.launcher.plist
-    ```
-2. Delete files, configuration and binaries
-    ```zsh
-    sudo /bin/rm -rf /usr/local/kolide-k2
-    sudo /bin/rm -rf /etc/kolide-k2
-    sudo /bin/rm -rf /var/kolide-k2
-    ```
-3. Uninstall the naisdevice Homebrew cask
-    ```bash
-    brew uninstall --force naisdevice
-    ```
+=== "macOS"
 
-### Windows uninstall
+    1. Stop and remove Kolide and the related launch mechanisms
+        ```zsh
+        sudo /bin/launchctl unload /Library/LaunchDaemons/com.kolide-k2.launcher.plist
+        sudo /bin/rm -f /Library/LaunchDaemons/com.kolide-k2.launcher.plist
+        ```
+    2. Delete files, configuration and binaries
+        ```zsh
+        sudo /bin/rm -rf /usr/local/kolide-k2
+        sudo /bin/rm -rf /etc/kolide-k2
+        sudo /bin/rm -rf /var/kolide-k2
+        ```
+    3. Uninstall the naisdevice Homebrew cask
+        ```bash
+        brew uninstall --force naisdevice
+        ```
 
-1. Uninstall _Kolide_ from Apps & Features 
-2. (Optionally) Uninstall _WireGuard_ from Apps & Features
-3. Uninstall naisdevice
-   * Installed with Scoop
-     ```powershell
-     scoop uninstall naisdevice
-     ```
-   * Installed manually
-     * Uninstall _naisdevice_ from Apps & Features
+=== "Windows (Scoop)"
 
-### Ubuntu uninstall
+    1. Uninstall _Kolide_ from Apps & Features
+    2. (Optionally) Uninstall _WireGuard_ from Apps & Features
+    3. Uninstall naisdevice
+        ```powershell
+        scoop uninstall naisdevice
+        ```
 
-1. Stop and remove Kolide and the related launch mechanisms
-    ```bash
-    sudo systemctl stop launcher.kolide-k2.service
-    sudo systemctl disable launcher.kolide-k2.service
-    ```
-2. Uninstall Kolide program files
-    ```bash
-    sudo apt(-get) remove launcher-kolide-k2
-    ```
-3. Delete Kolide files & caches
-    ```bash
-    sudo rm -r /{etc,var}/kolide-k2
-    ```
-4. Uninstall the naisdevice deb package
-    ```bash
-    sudo apt remove naisdevice
-    ```
+=== "Windows (Manual)"
+
+    1. Uninstall _Kolide_ from Apps & Features
+    2. (Optionally) Uninstall _WireGuard_ from Apps & Features
+    3. Uninstall _naisdevice_ from Apps & Features
+
+=== "Ubuntu"
+
+    1. Stop and remove Kolide and the related launch mechanisms
+        ```bash
+        sudo systemctl stop launcher.kolide-k2.service
+        sudo systemctl disable launcher.kolide-k2.service
+        ```
+    2. Uninstall Kolide program files
+        ```bash
+        sudo apt(-get) remove launcher-kolide-k2
+        ```
+    3. Delete Kolide files & caches
+        ```bash
+        sudo rm -r /{etc,var}/kolide-k2
+        ```
+    4. Uninstall the naisdevice deb package
+        ```bash
+        sudo apt remove naisdevice
+        ```
 
 ## OS-agnostic uninstall steps
 
@@ -65,31 +68,33 @@ This is necessary so that the record of your device can be purged from our Kolid
 
 {% else %}
 
-### macOS uninstall
+=== "macOS"
 
-Uninstall the naisdevice Homebrew cask
+    Uninstall the naisdevice Homebrew cask
 
-```bash
-brew uninstall --force naisdevice
-```
+    ```bash
+    brew uninstall --force naisdevice-tenant
+    ```
 
-### Windows uninstall
+=== "Windows (Scoop)"
 
-1. (Optionally) Uninstall _WireGuard_ from Apps & Features
-2. Uninstall naisdevice
-    * Installed with Scoop
-      ```powershell
-      scoop uninstall naisdevice
-      ```
-    * Installed manually
-        * Uninstall _naisdevice_ from Apps & Features
+    1. (Optionally) Uninstall _WireGuard_ from Apps & Features
+    2. Uninstall naisdevice
+        ```powershell
+        scoop uninstall naisdevice-tenant
+        ```
 
-### Ubuntu uninstall
+=== "Windows (Manual)"
 
-Uninstall the naisdevice deb package
+    1. (Optionally) Uninstall _WireGuard_ from Apps & Features
+    2. Uninstall _naisdevice_ from Apps & Features
 
-```bash
-sudo apt remove naisdevice
-```
+=== "Ubuntu"
+
+    Uninstall the naisdevice deb package
+
+    ```bash
+    sudo apt remove naisdevice-tenant
+    ```
 
 {% endif %}

--- a/docs/operate/naisdevice/how-to/update.md
+++ b/docs/operate/naisdevice/how-to/update.md
@@ -2,31 +2,70 @@
 tags: [naisdevice, how-to]
 ---
 
-# Updating naisdevice
+# Update naisdevice
 
 === "macOS"
 
-    1. Request privileges by running `Privileges.app` 
+    1. Request privileges by running `Privileges.app`
     2. Open a Terminal window.
     3. Run the following command:
+
+    {% if tenant() == "nav" %}
 
     ```bash
     brew update && brew upgrade naisdevice
     ```
+    {% else %}
 
-=== "Windows"
+    ```bash
+    brew update && brew upgrade naisdevice-tenant
+    ```
 
-    ### If you installed using scoop
+    {% endif %}
+
+=== "Windows (Scoop)"
+
+    {% if tenant() == "nav" %}
+
     ```powershell
     scoop update naisdevice
     ```
-    ### Manual installation
+
+    {% else %}
+
+    ```powershell
+    scoop update naisdevice-tenant
+    ```
+
+    {% endif %}
+
+=== "Windows (Manual)"
+
+    {% if tenant() == "nav" %}
+
     Download and run the newest [naisdevice installer](https://github.com/nais/device/releases/latest) \(naisdevice.exe\).
 
+    {% else %}
+
+    Download and run the newest [naisdevice installer](https://github.com/nais/device/releases/latest) \(naisdevice-tenant.exe\).
+
+    {% endif %}
+
 === "Ubuntu"
+
     1. Open a Terminal window.
     2. Run the following command:
-    
+
+    {% if tenant() == "nav" %}
+
     ```shell
     apt-get install --only-upgrade naisdevice
     ```
+
+    {% else %}
+
+    ```shell
+    apt-get install --only-upgrade naisdevice-tenant
+    ```
+
+    {% endif %}


### PR DESCRIPTION
- Specify use of `nais-device` tenant package for tenants other than `nav`
- Standardise tab-formatting
- Separate instructions for `Windows (Scoop)` and `Windows (Manual)`
- Heading in Update instructions uses imperative case

Resolves #682 