### PR TITLE
auth: nevne wonderwall i tittel

### DIFF
--- a/docs/auth/explanations/README.md
+++ b/docs/auth/explanations/README.md
@@ -591,7 +591,7 @@ verify the signature of your client assertions as proof of your client's identit
 
 ---
 
-## Login proxy
+## Login proxy (Wonderwall)
 
 NAIS offers an opt-in _login proxy_ (also known as _Wonderwall_) that simplifies the process of authenticating end-users in your application.
 


### PR DESCRIPTION
Mange bruker Wonderwall når man snakker om login proxy, som betyr at det er Wonderwall man ser etter i docen vår, ikke login proxy.