### PR TITLE
Legg til logging av Logback initialisering i eksempelkonfig

### DIFF
--- a/docs/observability/logging/how-to/enable-secure-logs.md
+++ b/docs/observability/logging/how-to/enable-secure-logs.md
@@ -79,6 +79,9 @@ Example configuration selecting which logs go to secure logs
 
     ```xml
     <configuration>
+        <!-- Log detailed information about the Logback initialization process at application startup. -->
+        <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
+    
         <appender name="appLog" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
             <filter class="ch.qos.logback.core.filter.EvaluatorFilter">


### PR DESCRIPTION
Litt ekstra info i loggen om Logback config når applikasjonen starter opp. Dette var veldig nyttig for meg da jeg prøvde å finne ut hvorfor logging requests som var ment for Securelogs havnet i ordninær applogg istedenfor: Jeg kunne se at det var logback.xml-fila fra en av appens dependecies som ble brukt istedenfor min egen app sin logback.xml.