### PR TITLE
Reduser filstørrelse for Securelogs i eksempel logback.xml

### DIFF
--- a/docs/observability/logging/how-to/enable-secure-logs.md
+++ b/docs/observability/logging/how-to/enable-secure-logs.md
@@ -101,7 +101,7 @@ Example configuration selecting which logs go to secure logs
                 <maxIndex>1</maxIndex>
             </rollingPolicy>
             <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-                <maxFileSize>128MB</maxFileSize>
+                <maxFileSize>64MB</maxFileSize>
             </triggeringPolicy>
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
             <filter class="ch.qos.logback.core.filter.EvaluatorFilter">


### PR DESCRIPTION
fordi @tengvig  har sett problemer med et par av team Toi sine apper. 128MB er maksimal størrelse (fra Nais?). Når logback.xml konfig sier 128MB - som i teorien skulle gå bra - og det kommer en burst av logging events kan filen blir større enn maksgrensen (128MB) før den rekker å bli rotert, og det setter Kubernetes-podden i en "unknown state" eller noe sånt. Reduserer til 64MB, som er et tilfeldig valgt tall som er godt under maks størrelse.