### PR TITLE
Fikset rekkefølge i nais postgres users add kommando

### DIFF
--- a/docs/operate/cli/reference/postgres.md
+++ b/docs/operate/cli/reference/postgres.md
@@ -130,7 +130,7 @@ By default the user is granted select privileges to the database public schema
 The privilege level can be altered with the `--privilege` flag.
 
 ```bash
-nais postgres users add username password appname
+nais postgres users add appname username password
 ```
 
 | Argument    | Required  | Description                                                 |


### PR DESCRIPTION
appname sto sist, men skal være først av argumentene ref: 
USAGE:
   nais postgres users add [command options] appname username password