### PR TITLE
Fix entra m2m example for generating a development token

### DIFF
--- a/docs/auth/entra-id/how-to/generate.md
+++ b/docs/auth/entra-id/how-to/generate.md
@@ -65,8 +65,7 @@ where `<audience>` is the intended _audience_ of the token, in this case the tar
 For example, in `curl`:
 
 ```bash
-curl -s -X POST "https://azure-token-generator.intern.dev.nav.no/api/public/m2m" \
-  -d "aud=dev-gcp:my-team:my-app"
+curl -s -X POST "https://azure-token-generator.intern.dev.nav.no/api/public/m2m?aud=dev-gcp:my-team:my-app"
 ```
 
 This returns an access token which can be used as a [Bearer token](../../explanations/README.md#bearer-token) to consume the target API application.


### PR DESCRIPTION
The current example gives me the following error:  missing 'aud' query parameter

The provided commit sees to work as intended.