### PR TITLE
Update links to Aiven docs

### DIFF
--- a/docs/operate/cli/reference/aiven.md
+++ b/docs/operate/cli/reference/aiven.md
@@ -169,7 +169,7 @@ kcat \
     -X ssl.ca.location=ca.pem
 ```
 
-For more details [aiven-kcat](https://help.aiven.io/en/articles/2607674-using-kafkacat)
+For more details [aiven-kcat](https://aiven.io/docs/products/kafka/howto/kcat)
 
 #### java
 

--- a/docs/persistence/kafka/README.md
+++ b/docs/persistence/kafka/README.md
@@ -74,4 +74,4 @@ If the new instances are not able to connect to Kafka, keeping the old ones unti
 ### Are Schemas backed up?
 !!! faq "Answer"
     Aiven makes backups of configuration and schemas every 3 hours, but no topic data is backed up by default.
-See the [Aiven documentation](https://docs.aiven.io/docs/products/kafka/concepts/configuration-backup) for more details.
+See the [Aiven documentation](https://aiven.io/docs/products/kafka/concepts/configuration-backup) for more details.

--- a/docs/persistence/kafka/explanations/offset.md
+++ b/docs/persistence/kafka/explanations/offset.md
@@ -136,5 +136,5 @@ You can use this query to get offsets for a consumer group:
 [offset-management]: https://docs.confluent.io/platform/current/clients/consumer.html#offset-management
 [rebalance]: https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#rebalancecallback
 [seek]: https://kafka.apache.org/28/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#seek(org.apache.kafka.common.TopicPartition,long)
-[aiven-offset-help]: https://developer.aiven.io/docs/products/kafka/howto/viewing-resetting-offset
+[aiven-offset-help]: https://aiven.io/docs/products/kafka/howto/viewing-resetting-offset
 

--- a/docs/persistence/kafka/how-to/access.md
+++ b/docs/persistence/kafka/how-to/access.md
@@ -38,10 +38,10 @@ The owner of the topic must [grant your application access to the topic](manage-
 Aiven has written several articles on how to configure your application.
 We use SSL, so ignore the SASL-SSL examples:
 
-- [Java](https://docs.aiven.io/docs/products/kafka/howto/connect-with-java.html)
-- [Python](https://docs.aiven.io/docs/products/kafka/howto/connect-with-python.html)
-- [Node.js](https://docs.aiven.io/docs/products/kafka/howto/connect-with-nodejs.html)
-- [Go](https://docs.aiven.io/docs/products/kafka/howto/connect-with-go.html)
+- [Java](https://aiven.io/docs/products/kafka/howto/connect-with-java)
+- [Python](https://aiven.io/docs/products/kafka/howto/connect-with-python)
+- [Node.js](https://aiven.io/docs/products/kafka/howto/connect-with-nodejs)
+- [Go](https://aiven.io/docs/products/kafka/howto/connect-with-go)
 
 For all available environment variables, see the [reference](../reference/environment-variables.md).
 

--- a/docs/persistence/kafka/reference/environment-variables.md
+++ b/docs/persistence/kafka/reference/environment-variables.md
@@ -26,7 +26,7 @@ These variables are made available to your application when Kafka is enabled.
 Aiven has written several articles on how to configure your application.
 We use SSL, so ignore the SASL-SSL examples:
 
-- [Java](https://docs.aiven.io/docs/products/kafka/howto/connect-with-java.html)
-- [Python](https://docs.aiven.io/docs/products/kafka/howto/connect-with-python.html)
-- [Node.js](https://docs.aiven.io/docs/products/kafka/howto/connect-with-nodejs.html)
-- [Go](https://docs.aiven.io/docs/products/kafka/howto/connect-with-go.html)
+- [Java](https://aiven.io/docs/products/kafka/howto/connect-with-java)
+- [Python](https://aiven.io/docs/products/kafka/howto/connect-with-python)
+- [Node.js](https://aiven.io/docs/products/kafka/howto/connect-with-nodejs)
+- [Go](https://aiven.io/docs/products/kafka/howto/connect-with-go)

--- a/docs/persistence/kafka/reference/monitoring.md
+++ b/docs/persistence/kafka/reference/monitoring.md
@@ -51,4 +51,4 @@ sum by(topic) (rate(kafka_server_BrokerTopicMetrics_BytesInPerSec_Count{topic="T
 
 ## Read more
 
-<https://help.aiven.io/en/articles/3298562-kafka-metrics-through-prometheus-integration>
+<https://aiven.io/docs/products/kafka/kafka-connect/reference/connect-metrics-prometheus>


### PR DESCRIPTION
I started this PR because half the links to Aiven docs were broken.
The issue was that Aiven was redirecting to broken URLs.

In the time it took to create this PR, Aiven had fixed their redirects.

I guess this PR is just updating the links to Aiven docs to avoid unnecessary redirects now 🤷
Maybe their redirects break again in the future. With this PR, hopefully we won't notice.

---

Here is the original description of the PR/issue, from before I double checked all the links just before clicking `Create PR`:
> Fixes a few broken links to Aiven docs. Aiven is redirecting them without the `/docs/` prefix, resulting in `404` pages.
> 
> Updates other Aiven links, removing subdomains (`docs`, `help` and `developer`) and updating paths, that redirect to `aiven.io/docs/[...]`.