### PR TITLE
Add Nais API docs and fix content-watcher module resolution

### DIFF
--- a/docs/operate/.pages
+++ b/docs/operate/.pages
@@ -1,7 +1,7 @@
 nav:
 - README.md
 - 🎯 How-To: how-to
-- Console: console.md
+- Nais Console: console
 - CLI: cli
 - naisdevice: naisdevice
 - ...

--- a/docs/operate/console/README.md
+++ b/docs/operate/console/README.md
@@ -2,7 +2,7 @@
 tags: [console, explanation, operate]
 ---
 
-# Console
+# Nais Console
 
 Nais Console is a web-based interface for managing your workloads and services on the Nais platform. It aims to provide a user-friendly way to interact with the platform, without needing to use the command line.
 
@@ -10,4 +10,4 @@ It tries to provide you with insight into what you've got running on the platfor
 
 The Console is designed to be self-service, meaning that you can manage your workloads and services without needing to involve the Nais team. This includes creating, updating, and deleting workloads, as well as managing secrets and other resources.
 
-Access Nais Console at [console.<<tenant()>>.cloud.nais.io](https://console.<<tenant()>>.cloud.nais.io).
+Access Nais Console at <<tenant_url("console")>>.

--- a/docs/operate/console/api.md
+++ b/docs/operate/console/api.md
@@ -1,0 +1,59 @@
+# Nais API
+
+Nais API is a GraphQL API that allows programmatic access to the Nais platform.
+
+## Endpoint
+
+The API endpoint is available at `<<tenant_url("console")>>graphql`
+
+## Service Accounts
+
+Access to the API requires authentication.
+For programmatic access, you must set up a service account in [Nais Console](<<tenant_url("console")>>):
+
+1. Navigate to your team in Nais Console.
+2. Go to the **Settings** page.
+3. Click on the **Service accounts** tab.
+4. Click the **Create service account** button.
+5. Follow the prompts to create a new service account.
+6. Configure an **Authentication method** for the service account.
+
+### Workload Binding
+
+To access the API from a workload running on Nais, set up the **Workload binding** authentication method for your service account.
+
+Workloads on Nais are configured with a workload token, available as a file at the path specified by the `NAIS_SERVICE_ACCOUNT_TOKEN_PATH` environment variable.
+The token is periodically rotated; re-read the file before use rather than caching its contents.
+
+Use the token as a Bearer token in the `Authorization` header when making requests to the API:
+
+```http
+POST /graphql HTTP/1.1
+Host: console.<<tenant()>>.cloud.nais.io
+Authorization: Bearer $(cat $NAIS_SERVICE_ACCOUNT_TOKEN_PATH)
+```
+
+### API Tokens
+
+To access the API from outside the Nais platform, set up the **API token** authentication method for your service account.
+Configure an expiration date for the token and rotate it regularly.
+
+Use the token as a Bearer token in the `Authorization` header when making requests to the API:
+
+```http
+POST /graphql HTTP/1.1
+Host: console.<<tenant()>>.cloud.nais.io
+Authorization: Bearer $API_TOKEN
+```
+
+## Local Development
+
+For local development, use [the `nais` CLI](https://cli.nais.io):
+
+```shell
+nais api proxy
+```
+
+This starts a local proxy that forwards requests to the Nais API using your personal credentials.
+
+The proxy also exposes a GraphQL playground at `http://localhost:4242` by default for exploring the API and testing queries.

--- a/svdoc/src/lib/vite-plugin-content-watcher.ts
+++ b/svdoc/src/lib/vite-plugin-content-watcher.ts
@@ -26,6 +26,11 @@ export function contentWatcherPlugin(): Plugin {
 			watcher.add(DOCS_DIR);
 
 			// Handle file changes
+			const loadContentStore = async () => {
+				const mod = await server!.ssrLoadModule("/src/lib/content-store");
+				return mod.contentStore;
+			};
+
 			const handleChange = async (filePath: string) => {
 				// Only handle markdown and .pages files
 				if (!filePath.endsWith(".md") && !filePath.endsWith(".pages")) {
@@ -41,7 +46,7 @@ export function contentWatcherPlugin(): Plugin {
 
 				// Invalidate the content store
 				try {
-					const { contentStore } = await import(/* @vite-ignore */ "./content-store");
+					const contentStore = await loadContentStore();
 					await contentStore.invalidateFile(filePath);
 				} catch (error) {
 					console.error("[content-watcher] Failed to invalidate content store:", error);
@@ -69,7 +74,7 @@ export function contentWatcherPlugin(): Plugin {
 
 				// Invalidate the entire store on deletion
 				try {
-					const { contentStore } = await import(/* @vite-ignore */ "./content-store");
+					const contentStore = await loadContentStore();
 					await contentStore.invalidateAll();
 				} catch (error) {
 					console.error("[content-watcher] Failed to invalidate content store:", error);


### PR DESCRIPTION
- Add reference docs for the Nais GraphQL API (service accounts, auth methods, local dev)
- Restructure console into its own directory section
- Fix content-watcher failing to resolve content-store during dev by using `ssrLoadModule` instead of relative dynamic import

Depends on https://github.com/nais/console-frontend/pull/421.