### PR TITLE
Clarify opt-out instructions for Salsa in sbom.md

### DIFF
--- a/docs/services/vulnerabilities/how-to/sbom.md
+++ b/docs/services/vulnerabilities/how-to/sbom.md
@@ -15,10 +15,10 @@ Simply add [nais/docker-build-push](https://github.com/nais/docker-build-push) t
      # ... other options removed for readability
 ```
 
-??? note Opt-out
-    Opt-out from salsa
+??? note "Opt out"
+    Opt out of Salsa for this workload.
 
-    If you want to opt-out from salsa you can set the salsa input to false
+    If you want to opt out of Salsa, set the `salsa` input to `false`.
 
     ```yaml
     salsa: false


### PR DESCRIPTION
Update to the documentation for opting out of Salsa in the SBOM workflow. The change clarifies the instructions and improves the formatting of the note.