### PR TITLE
Update label docs to remove prefix requirement

### DIFF
--- a/docs/operate/explanations/labels.md
+++ b/docs/operate/explanations/labels.md
@@ -10,7 +10,7 @@ A label might describe ownership, a project, an environment grouping, or anythin
 
 ## How labels work on Nais
 
-Labels on Nais are regular [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). You can use any key and value that follows the standard Kubernetes label syntax — no special prefix is required.
+Labels on Nais are regular [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). You can use any key and value that follows the standard Kubernetes label syntax.
 
 ```text
 <key>: <value>

--- a/docs/operate/explanations/labels.md
+++ b/docs/operate/explanations/labels.md
@@ -10,15 +10,23 @@ A label might describe ownership, a project, an environment grouping, or anythin
 
 ## How labels work on Nais
 
-Labels on Nais are regular [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) with one requirement: the key must use the `labels.nais.io/` prefix.
+Labels on Nais are regular [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). You can use any key and value that follows the standard Kubernetes label syntax — no special prefix is required.
 
 ```text
-labels.nais.io/<key>: <value>
+<key>: <value>
 ```
 
-This prefix keeps your own labels clearly separated from the labels that Nais manage internally, so the two never collide.
-
 When you set a label on a resource, Nais keeps it verbatim and propagates it to the underlying Kubernetes resources that the resource owns. For a [workload](../../workloads/README.md), this means the label is also applied to the resources Nais generates on your behalf.
+
+## Hidden labels
+
+Nais surfaces all labels on your resources, except for a few that Nais and Kubernetes manage internally. The following labels are hidden in [Nais Console](../console/README.md) and the [Nais API](../console/api.md):
+
+- the `app` label
+- the `team` label
+- any label whose key contains the substring `nais.io/`
+
+These labels are still present on the underlying Kubernetes resources — they are only hidden from the Nais-managed views.
 
 ## Where you can use labels
 

--- a/docs/operate/how-to/labels.md
+++ b/docs/operate/how-to/labels.md
@@ -8,7 +8,7 @@ This guide shows you how to add [labels](../explanations/labels.md) to your reso
 
 ## Add labels in your manifest
 
-Add your labels under `metadata.labels`, using the `labels.nais.io/` prefix:
+Add your labels under `metadata.labels`:
 
 === "app.yaml"
 
@@ -19,8 +19,8 @@ Add your labels under `metadata.labels`, using the `labels.nais.io/` prefix:
       name: <MY-APP>
       namespace: <MY-TEAM>
       labels:
-        labels.nais.io/team-area: payments
-        labels.nais.io/sensitive: "true"
+        team-area: payments
+        cost-center: "1234"
     spec:
       ...
     ```
@@ -33,7 +33,7 @@ You can add and edit labels from Console for [Valkey](../../persistence/valkey/R
 
 1. Open [Nais Console](<<tenant_url("console")>>) and navigate to the resource you want to label.
 2. Find the **Labels** section in the sidebar and click the edit icon.
-3. Enter a key and a value. The `labels.nais.io/` prefix is added automatically.
+3. Enter a key and a value.
 4. Click **Add label** to add more labels.
 5. Click **Save**.
 

--- a/docs/operate/how-to/labels.md
+++ b/docs/operate/how-to/labels.md
@@ -20,7 +20,7 @@ Add your labels under `metadata.labels`:
       namespace: <MY-TEAM>
       labels:
         team-area: payments
-        cost-center: "1234"
+        sensitive: "true"
     spec:
       ...
     ```

--- a/docs/operate/reference/labels.md
+++ b/docs/operate/reference/labels.md
@@ -11,20 +11,33 @@ Labels are user-defined key-value pairs used to organize and categorize your res
 A label consists of a key and a value:
 
 ```text
-labels.nais.io/<key>: <value>
+<key>: <value>
 ```
 
 | Part | Description |
 |:-----|:------------|
-| `labels.nais.io/` | Required prefix. It is the only constraint Nais adds on top of the standard Kubernetes label rules. |
 | `<key>` | Your label name. Must follow the [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 | `<value>` | Your label value. Must follow the [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
+
+No Nais-specific prefix is required.
 
 ## Behavior
 
 - Labels are kept **verbatim** — Nais does not rewrite or strip them.
 - Labels are **propagated** to the underlying Kubernetes resources that the resource owns.
 - Labels carry **no special meaning** to Nais. They are only used for your own organization.
+
+## Hidden labels
+
+[Nais Console](../console/README.md) and the [Nais API](../console/api.md) surface all labels on a resource, except for the following internal labels, which are hidden:
+
+| Label key | Match |
+|:----------|:------|
+| `app` | Exact match |
+| `team` | Exact match |
+| `*nais.io/*` | Any key containing the substring `nais.io/` |
+
+Hidden labels remain present on the underlying Kubernetes resources.
 
 ## Setting labels
 
@@ -37,13 +50,13 @@ metadata:
   name: myapplication
   namespace: myteam
   labels:
-    labels.nais.io/team-area: payments
-    labels.nais.io/sensitive: "true"
+    team-area: payments
+    cost-center: "1234"
 spec:
   ...
 ```
 
-Labels can also be added and edited from [Nais Console](../console/README.md) for [Valkey](../../persistence/valkey/README.md), [OpenSearch](../../persistence/opensearch/README.md), [Config](../../services/config/README.md), and [Secret](../../services/secrets/README.md). 
+Labels can also be added and edited from [Nais Console](../console/README.md) for [Valkey](../../persistence/valkey/README.md), [OpenSearch](../../persistence/opensearch/README.md), [Config](../../services/config/README.md), and [Secret](../../services/secrets/README.md).
 
 ## Related pages
 

--- a/docs/operate/reference/labels.md
+++ b/docs/operate/reference/labels.md
@@ -19,8 +19,6 @@ A label consists of a key and a value:
 | `<key>` | Your label name. Must follow the [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 | `<value>` | Your label value. Must follow the [Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
 
-No Nais-specific prefix is required.
-
 ## Behavior
 
 - Labels are kept **verbatim** — Nais does not rewrite or strip them.

--- a/docs/operate/reference/labels.md
+++ b/docs/operate/reference/labels.md
@@ -49,7 +49,7 @@ metadata:
   namespace: myteam
   labels:
     team-area: payments
-    cost-center: "1234"
+    sensitive: "true"
 spec:
   ...
 ```


### PR DESCRIPTION
Document that labels follow standard Kubernetes syntax without a `labels.nais.io/` prefix, update examples accordingly, and clarify that internal labels (`app`, `team`, and keys containing `nais.io/`) are hidden in Console and API views.

Requires https://github.com/nais/console-frontend/pull/487