### PR TITLE
Add priority vulnerability alert docs

### DIFF
--- a/docs/services/vulnerabilities/how-to/alert-on-vulnerabilities.md
+++ b/docs/services/vulnerabilities/how-to/alert-on-vulnerabilities.md
@@ -1,13 +1,13 @@
 ---
-description: Set up Prometheus or Grafana alerts when critical vulnerabilities or high risk scores are detected in your workloads.
-tags: [how-to, vulnerabilities, alerting, prometheus]
+description: Set up Prometheus or Grafana alerts for vulnerability findings in your workloads, including critical severity, priority-based findings, and high risk scores.
+tags: [how-to, vulnerabilities, alerting, prometheus, grafana]
 ---
 
 # Alert on vulnerabilities
 
-This guide shows you how to set up alerts when new critical vulnerabilities are detected in your workloads.
+This guide shows you how to set up alerts when critical, priority-based, or high-risk vulnerability findings are present in your workloads.
 
-Nais exposes Prometheus metrics for vulnerability status and risk per workload. You can use these to alert your team via Slack or Grafana.
+Nais exposes Prometheus metrics for vulnerability counts, priority, and risk per workload. You can use these to alert your team via Slack or Grafana.
 
 ## Prerequisites
 
@@ -42,6 +42,55 @@ Create a `PrometheusRule` in your namespace that triggers an alert when the numb
               labels:
                 namespace: <MY-TEAM>
                 severity: critical
+    ```
+
+## Alert on priority (ACT_NOW and HIGH)
+
+Nais also exposes a priority-based metric for the two highest-priority classes: `nais_workload_vulnerabilities_priority`.
+
+Use this when you want exploitability-driven urgency, not only CVSS severity.
+
+- `ACT_NOW`: `has_kev_entry=true`, based on [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
+  This means known exploitation in the wild and should be treated as highest remediation priority.
+- `HIGH`: `has_kev_entry=false` and (`known_ransomware_use=true` or [EPSS](https://www.first.org/epss/) percentile `>= 0.90`).
+  This means elevated likelihood of exploitation and should be handled quickly.
+
+A CVE is counted in only one of these classes. If it has a KEV entry, it is counted as `ACT_NOW`, not `HIGH`.
+
+???+ note ".nais/alert-priority-vulnerabilities.yaml"
+
+    ```yaml
+    apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+      name: priority-vulnerability-alerts
+      namespace: <MY-TEAM>
+      labels:
+        team: <MY-TEAM>
+    spec:
+      groups:
+        - name: priority-vulnerability-alerts
+          rules:
+            - alert: ActNowVulnerability
+              expr: nais_workload_vulnerabilities_priority{priority="ACT_NOW", workload_namespace="<MY-TEAM>"} > 0
+              for: 10m
+              annotations:
+                summary: "ACT_NOW vulnerability detected in {{ $labels.workload_name }}"
+                consequence: "The workload has one or more ACT_NOW vulnerabilities."
+                action: "Open Nais Console and handle the vulnerability for {{ $labels.workload_name }}."
+              labels:
+                namespace: <MY-TEAM>
+                severity: critical
+            - alert: HighPriorityVulnerability
+              expr: nais_workload_vulnerabilities_priority{priority="HIGH", workload_namespace="<MY-TEAM>"} > 0
+              for: 10m
+              annotations:
+                summary: "High-priority vulnerability detected in {{ $labels.workload_name }}"
+                consequence: "The workload has one or more HIGH priority vulnerabilities."
+                action: "Open Nais Console and handle the vulnerability for {{ $labels.workload_name }}."
+              labels:
+                namespace: <MY-TEAM>
+                severity: warning
     ```
 
 ## Alert on high risk score
@@ -82,23 +131,25 @@ A workload with 1 critical vulnerability scores 10, while 20 critical vulnerabil
                 severity: warning
     ```
 
-## Activate the alert
+## Activate alerts
 
 === "Automatically"
-    Add the file to your application repository and deploy with [Nais GitHub Action](../../../build/how-to/build-and-deploy.md).
+    Add the rule file to your application repository and deploy it with [Nais GitHub Action](../../../build/how-to/build-and-deploy.md).
 
 === "Manually"
+    Apply the rule file you created, for example:
+
     ```bash
-    kubectl apply -f .nais/alert-vulnerabilities.yaml
+    kubectl apply -f .nais/alert-priority-vulnerabilities.yaml
     ```
 
-## Alert to a dedicated Slack channel
+## Send alerts to a dedicated Slack channel
 
 By default, alerts are sent to your team's standard Slack channel. If you want to send vulnerability alerts to a dedicated channel, create an `AlertmanagerConfig`.
 
 See [Advanced Prometheus alerting](../../../observability/alerting/how-to/prometheus-advanced.md) for a complete example with a custom Slack channel and webhook.
 
-## Alert in Grafana
+## Create alerts in Grafana
 
 Alternatively, you can create alerts directly in Grafana without deploying Kubernetes resources:
 
@@ -106,14 +157,14 @@ Alternatively, you can create alerts directly in Grafana without deploying Kuber
 2. Click **New alert rule**
 3. Select the Prometheus/Mimir data source that contains `nais_workload_*` metrics and use e.g.:
    ```promql
-   nais_workload_vulnerabilities{severity="CRITICAL", workload_namespace="<MY-TEAM>"}
+   nais_workload_vulnerabilities_priority{priority="ACT_NOW", workload_namespace="<MY-TEAM>"}
    ```
 4. Set the threshold and connect to a Slack contact point
 
 See [Create alert in Grafana](../../../observability/alerting/how-to/grafana.md) for a complete step-by-step guide.
 
-???+ note "Metric update delay after suppression"
-    After suppressing a vulnerability, the database is updated immediately, but Prometheus metrics (`nais_workload_vulnerabilities`, `nais_workload_risk_score`) are refreshed on a periodic interval (default: 5 minutes). An active alert may therefore remain firing for up to 5 minutes after suppression.
+??? note "Metric update delay after suppression"
+    After suppressing a vulnerability, the database is updated immediately. Workload metrics (`nais_workload_vulnerabilities`, `nais_workload_vulnerabilities_priority`, `nais_workload_risk_score`) are recomputed periodically (default: every 5 minutes), and alerts clear only after updated metrics are pushed and scraped by Prometheus. Expect roughly a 5-minute delay, plus normal metrics propagation time.
 
 ## Learn more
 


### PR DESCRIPTION
Adds concise guidance for priority-based vulnerability alerting.

- document ACT_NOW and HIGH priority semantics
- add PrometheusRule example using nais_workload_vulnerabilities_priority
- align activation/Grafana sections with the new metric
- clarify suppression delay behavior for workload metrics