### PR TITLE
docs(frontend): @nais/apm v0.2.0 — React & browser tracing

### DIFF
--- a/docs/observability/apm/reference/apm-client-api.md
+++ b/docs/observability/apm/reference/apm-client-api.md
@@ -10,8 +10,10 @@ tags: [reference, observability, apm, frontend]
 
 `@nais/apm` wraps [`@grafana/faro-web-sdk`](https://github.com/grafana/faro-web-sdk)
 with an ergonomic, capture-oriented API. This page documents the public API of
-version `0.1.0`. For installation, see
-[Track frontend errors with `@nais/apm`](../tutorials/track-frontend-errors.md).
+version `0.2.0`. For installation, see
+[Track frontend errors with `@nais/apm`](../tutorials/track-frontend-errors.md);
+for React, Next.js, and browser tracing, see
+[React & Next.js with `@nais/apm`](../../frontend/how-to/react.md).
 
 !!! note "Pre-1.0"
     The public API may change across `0.x` minor releases (new options, renamed
@@ -45,6 +47,7 @@ each resolve independently (see [Configuration resolution](#configuration-resolu
 | `faro` | `Partial<BrowserConfig>` | Escape hatch: raw Faro overrides, merged last (except `beforeSend`, which stays composed with the scrubber). |
 | `sessionReplay` | object | Opt-in session replay. See [`sessionReplay`](#init-options) below. |
 | `screenshotOnError` | `boolean` | Opt-in masked DOM snapshot per new error. Off by default; auto-disabled when `sessionReplay` is enabled. |
+| `tracing` | `boolean \| { propagateExtraOrigins?: (string \| RegExp)[] }` | Opt-in browser tracing. Off by default. `true` enables it with the mandatory propagation floor (same-origin + `*.nav.no`); pass an object to append extra origins. See [Browser tracing](#browser-tracing). |
 
 `sessionReplay` fields: `enabled` (`boolean`), `mode` (`'on-error'` default, or
 `'always'`), `sampleRate` (`0..1`, default `1`), `block` (`string[]`,
@@ -227,6 +230,36 @@ sends **nothing** over the network, and echoes every signal to the console.
 Calling any capture function before `init()` is a safe no-op (with a single
 warning).
 
+## Browser tracing
+
+Enable distributed tracing with `init({ tracing: true })`. This lazily loads
+`@grafana/faro-web-tracing` (kept out of your bundle unless enabled) and
+propagates W3C trace-context headers so browser spans join their backend traces
+in Tempo.
+
+Trace-header propagation is restricted by a **non-overridable floor**: headers
+are only sent to the app's own origin and any `https://*.nav.no` host, so
+`traceparent` never leaks to third-party origins. Extra origins are **appended**
+via `propagateExtraOrigins` — they can never replace or empty the floor, and the
+floor is not reachable through the `faro` escape hatch.
+
+```ts
+init({ tracing: { propagateExtraOrigins: [/https:\/\/api\.partner\.example\/.*/] } });
+```
+
+See [Frontend-to-backend trace propagation](../../frontend/how-to/trace-propagation.md#recommended-enable-tracing-with-naisapm).
+
+## React entry — `@nais/apm/react`
+
+A separate entry point, `@nais/apm/react`, exposes React helpers without pulling
+React or the tracing tree into the root import: `ApmErrorBoundary` /
+`withApmErrorBoundary` (report render errors once through `captureException`),
+`ApmRoutes` / `enableApmReactRouterV6` and `useApmRouteTracking` (route-change
+tracking for React Router v6 and the Next.js App Router), and `initNaisAPMClient`
+(a server-safe, init-once Next.js client entry). React and `react-router` are
+optional peer dependencies. See
+[React & Next.js with `@nais/apm`](../../frontend/how-to/react.md).
+
 ## Supporting exports
 
 Beyond the primary API, `@nais/apm` also exports `DEFAULT_IGNORE_ERRORS`,
@@ -235,8 +268,7 @@ instrumentation that captures `console.error('msg', err)` with a real stack
 trace), `resolveConfig` / `versionFromImage`, `FEEDBACK_EVENT_NAME`, and
 `VERSION`. Most apps never need these directly.
 
-## Known limitations (0.1.0)
+## Known limitations (0.2.0)
 
-- No tracing support yet (`@grafana/faro-web-tracing` integration planned).
-- No `@nais/apm/react` entry point yet (e.g. an `ErrorBoundary`).
+- Route tracking covers React Router v6 and the Next.js App Router; React Router v5/v7 and the data-router variants are follow-ups.
 - Published to the GitHub Package Registry only.

--- a/docs/observability/frontend/README.md
+++ b/docs/observability/frontend/README.md
@@ -23,10 +23,10 @@ With 95+ applications already using Faro, it's the standard way to monitor front
     **view and triage** the results on the APM [Frontend](../apm/tutorials/get-started.md#4-look-at-backend-database-and-frontend)
     and [Issues](../apm/tutorials/get-started.md#3-check-the-issues-tab) tabs.
 
-    Start with [Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md).
-    Reach for raw Faro (the guides below) when you need something `@nais/apm`
-    doesn't cover yet — most notably [trace propagation](how-to/trace-propagation.md),
-    which the `0.1.0` SDK doesn't wrap.
+    Start with [Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md),
+    then add [React error boundaries, route tracking, and browser tracing](how-to/react.md).
+    Reach for raw Faro (the guides below) only for the few things `@nais/apm`
+    doesn't cover yet.
 {% endif %}
 
 ## What you get
@@ -42,10 +42,11 @@ With 95+ applications already using Faro, it's the standard way to monitor front
 
 {% if tenant() == "nav" %}
 1. **Recommended — errors as issues in APM:** [:dart: Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md)
-2. **Any frontend app (raw Faro):** [:dart: Set up Faro](how-to/setup-faro.md)
-3. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
-4. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
-5. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
+2. **React or Next.js app?** [:simple-react: React & Next.js with `@nais/apm`](how-to/react.md)
+3. **Any frontend app (raw Faro):** [:dart: Set up Faro](how-to/setup-faro.md)
+4. **Next.js App Router (raw Faro):** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
+5. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
+6. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
 {% else %}
 1. **Any frontend app:** [:dart: Set up Faro](how-to/setup-faro.md)
 2. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
@@ -121,6 +122,7 @@ For local development, check out the [tracing demo repository](https://github.co
 | Guide | Description |
 | ----- | ----------- |
 | [Set up Faro](how-to/setup-faro.md) | Install, configure, and deploy Faro in any frontend app |
+| [React & Next.js](how-to/react.md) | Error boundaries, route tracking, and browser tracing with `@nais/apm` |
 | [Next.js App Router](how-to/setup-nextjs.md) | Faro integration for Next.js with App Router |
 | [Custom metrics](how-to/custom-metrics.md) | Send custom measurements and query them in Grafana |
 | [Trace propagation](how-to/trace-propagation.md) | Connect frontend traces to backend spans |

--- a/docs/observability/frontend/how-to/react.md
+++ b/docs/observability/frontend/how-to/react.md
@@ -1,0 +1,270 @@
+---
+description: >-
+  Instrument React and Next.js apps with @nais/apm — error boundaries that
+  become fingerprinted issues, route tracking, and browser tracing.
+tags: [how-to, observability, frontend, react, next.js]
+---
+
+# React &amp; Next.js with `@nais/apm`
+
+{% if tenant() == "nav" %}
+The [`@nais/apm`](../../apm/reference/apm-client-api.md) SDK ships a separate
+React entry point, **`@nais/apm/react`**, with helpers for React and Next.js
+apps: an error boundary that turns a render crash into a fingerprinted issue in
+Nais APM, route-change tracking for React Router v6 and the Next.js App Router,
+and a server-safe Next.js client-init helper.
+
+The React entry keeps the root `@nais/apm` import free of React and the tracing
+dependency tree — you only pull those in if you import `@nais/apm/react`. React
+and `react-router` are **optional peer dependencies**: importing this entry
+requires them (plus `@grafana/faro-react` for the React Router v6 wiring).
+
+!!! note "Prerequisite"
+    Set up `@nais/apm` first — see
+    [Track frontend errors with `@nais/apm`](../../apm/tutorials/track-frontend-errors.md).
+    The helpers below assume `init()` has run.
+
+## Install
+
+```sh
+pnpm add @nais/apm
+# or: npm install @nais/apm / yarn add @nais/apm
+```
+
+The React helpers rely on peer dependencies you almost certainly already have:
+`react` (and `react-dom`), plus `react-router-dom` (v6) and `@grafana/faro-react`
+if you use the React Router v6 route tracking below.
+
+## Catch render errors with `ApmErrorBoundary`
+
+A React render error thrown below a component is otherwise silently swallowed —
+it never reaches `window.onerror`, so `@nais/apm` can't see it. Wrap your app
+(or a route subtree) in `ApmErrorBoundary`: it catches the error, reports it
+**exactly once** through `captureException` (so it gets the SDK's fingerprint
+and global context pipeline, with the React component stack attached), and
+renders a fallback.
+
+```tsx
+import { ApmErrorBoundary } from '@nais/apm/react';
+
+export function App() {
+  return (
+    <ApmErrorBoundary fallback={<p>Something went wrong.</p>}>
+      <Router />
+    </ApmErrorBoundary>
+  );
+}
+```
+
+Wrap route subtrees rather than only the root when you want a crash in one
+area to leave the rest of the app usable:
+
+```tsx
+<Layout>
+  <ApmErrorBoundary fingerprint="checkout" fallback={<CheckoutError />}>
+    <Checkout />
+  </ApmErrorBoundary>
+</Layout>
+```
+
+### Props
+
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| `fallback` | `ReactNode \| (error, resetError) => ReactNode` | What to render after a catch. A node, or a render function that receives the error and a `resetError` callback. Defaults to a minimal `role="alert"` message. |
+| `fingerprint` | `string \| (error) => string` | Custom grouping key, passed to `captureException` (maps to `context.fingerprint`). A function receives the caught error so grouping can depend on it. |
+| `context` | `Record<string, unknown>` | Extra context merged into the captured exception. |
+| `onError` | `(error, errorInfo) => void` | Called after the error has been captured. |
+| `onReset` | `(error \| null) => void` | Called when the boundary is reset via the render-prop `resetError`. |
+
+The render-prop `fallback` lets you offer a retry that clears the error state:
+
+```tsx
+<ApmErrorBoundary
+  fallback={(error, resetError) => (
+    <div role="alert">
+      <p>Could not load this view.</p>
+      <button onClick={resetError}>Try again</button>
+    </div>
+  )}
+>
+  <Report />
+</ApmErrorBoundary>
+```
+
+### `withApmErrorBoundary` HOC
+
+To wrap a component without editing its JSX, use the HOC — a Sentry-compatible
+`withErrorBoundary` shape:
+
+```tsx
+import { withApmErrorBoundary } from '@nais/apm/react';
+
+const SafeReport = withApmErrorBoundary(Report, { fingerprint: 'report' });
+```
+
+Errors caught by the boundary land on the **Issues** tab of your app in Nais
+APM, grouped by fingerprint, side by side with backend errors.
+
+![Nais APM Issues tab filtered to browser-sourced exceptions](../../../assets/nais-apm-service-navno-issues-frontend.png)
+
+## Track route changes
+
+Single-page apps navigate without a full page load, so Faro's default pageload
+instrumentation only sees the first route. Add route tracking so each in-app
+navigation is recorded — this is what powers per-page performance and session
+navigation trails in APM.
+
+### React Router v6
+
+Call `enableApmReactRouterV6` **once after `init()`**, passing your app's own
+`react-router-dom` exports (the SDK does not import react-router itself, so it
+stays an optional peer with no version drift). Then render `<ApmRoutes>` wherever
+you would render `<Routes>`:
+
+```tsx
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+import { enableApmReactRouterV6, ApmRoutes } from '@nais/apm/react';
+
+enableApmReactRouterV6({
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+});
+
+export function AppRoutes() {
+  return (
+    <ApmRoutes>
+      <Route path="/" element={<Home />} />
+      <Route path="/reports/:id" element={<Report />} />
+    </ApmRoutes>
+  );
+}
+```
+
+`ApmRoutes` is a drop-in for `<Routes>` that reports a route-change event on each
+navigation. React Router v5/v7 and the data-router variants are follow-ups.
+
+### Next.js App Router
+
+There is no faro-react integration for the Next.js App Router, so `@nais/apm`
+ships a small hook, `useApmRouteTracking`. Call it in a **client component** with
+Next's navigation hooks; it pushes a route-change event whenever the pathname (or
+search) changes:
+
+```tsx
+// app/ApmRouteTracker.tsx
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useApmRouteTracking } from '@nais/apm/react';
+
+export function ApmRouteTracker() {
+  useApmRouteTracking(usePathname(), useSearchParams());
+  return null;
+}
+```
+
+Render it once, high in your tree (e.g. in the root `app/layout.tsx`). Passing
+the values in — rather than importing `next/navigation` inside the SDK — keeps
+Next out of the package's dependency tree and makes the hook usable with any
+router that can supply a pathname.
+
+## Next.js setup
+
+Use `initNaisAPMClient` as the client entry. It is the documented entry for the
+Next 15+ [`instrumentation-client.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation-client)
+file and the Pages Router `_app.tsx` pattern:
+
+```ts
+// instrumentation-client.ts (Next 15+)
+import { initNaisAPMClient } from '@nais/apm/react';
+
+initNaisAPMClient({ namespace: 'my-team' });
+```
+
+```tsx
+// pages/_app.tsx (Pages Router)
+import type { AppProps } from 'next/app';
+import { initNaisAPMClient } from '@nais/apm/react';
+
+initNaisAPMClient({ namespace: 'my-team' });
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+`initNaisAPMClient` takes the same options as [`init()`](../../apm/reference/apm-client-api.md)
+(including `tracing`), and adds two Next-specific guarantees:
+
+- **Server-safe** — it no-ops when `window` is undefined, so you can import it
+  into modules that also run in React Server Components or during SSR without a
+  reference error. It returns the Faro instance in the browser, or `undefined`
+  on the server.
+- **Init-once** — `init()` already self-guards against double initialization, so
+  React StrictMode's double-invoke or repeated imports return the existing
+  instance instead of re-initializing.
+
+!!! warning "`namespace` is required"
+    Nais APM attributes all telemetry by team, so pass your nais team as
+    `namespace` (it maps to the `app_namespace` field). On a static frontend the
+    platform can inject it via a `<meta name="nais-team">` tag or the `NAIS_TEAM`
+    env, but for SSR/Next apps set it explicitly. Without it the SDK loud-warns
+    and falls back to `unknown-team` — it never throws.
+
+## Enable browser tracing
+
+Turn on distributed tracing for a React or Next.js app with a single option —
+it works the same everywhere `init()` runs, including `initNaisAPMClient`:
+
+```ts
+initNaisAPMClient({ namespace: 'my-team', tracing: true });
+```
+
+This connects browser spans to your backend traces in Tempo. See
+[Frontend-to-backend trace propagation](trace-propagation.md#recommended-enable-tracing-with-naisapm)
+for the full story, including the trace-header propagation security model.
+
+## Keep user ids opaque
+
+`setUser` is the developer's responsibility — `@nais/apm` scrubs fødselsnummer,
+emails, and token URL parameters from outgoing signals, but the id you pass to
+`setUser` is trusted. Pass only an **opaque, non-identifying** correlation key
+(a salted hash), never a raw NAV ident, fødselsnummer, email, or name — every
+team shares the same Loki instance.
+
+```ts
+import { setUser, clearUser } from '@nais/apm';
+
+setUser({ id: hashedSubject }); // hashedSubject = a salted hash, NOT an ident/fnr/email
+// ... on logout:
+clearUser();
+```
+
+See [Privacy: PII scrubbing](../../apm/reference/apm-client-api.md#privacy-pii-scrubbing)
+for exactly what the mandatory scrubber covers.
+
+## Related
+
+- [Track frontend errors with `@nais/apm`](../../apm/tutorials/track-frontend-errors.md) — install and initialize the SDK
+- [`@nais/apm` API reference](../../apm/reference/apm-client-api.md) — every export and option
+- [Frontend-to-backend trace propagation](trace-propagation.md) — enable and verify distributed traces
+- [View errors on the Issues tab](../../apm/tutorials/get-started.md#3-check-the-issues-tab) and [browser data on the Frontend tab](../../apm/tutorials/get-started.md#4-look-at-backend-database-and-frontend) in Nais APM
+{% else %}
+On tenants where `@nais/apm` is not yet available, instrument React apps with the
+underlying [`@grafana/faro-react`](https://www.npmjs.com/package/@grafana/faro-react)
+package directly:
+
+- [`<FaroErrorBoundary>`](setup-faro.md#react-error-boundaries) — catch React render errors
+- [`<FaroRoutes>` and the Next.js error-boundary pattern](setup-nextjs.md#react-integration-package) — route tracking and Next.js integration
+- [Trace propagation](trace-propagation.md) — connect browser traces to backend spans
+{% endif %}

--- a/docs/observability/frontend/how-to/setup-faro.md
+++ b/docs/observability/frontend/how-to/setup-faro.md
@@ -14,9 +14,10 @@ Add [Grafana Faro](https://www.npmjs.com/package/@grafana/faro-web-sdk) to a fro
     SDK — a thin Faro wrapper that gives you zero-config `init()`, **built-in PII
     scrubbing** (fødselsnummer, emails, and token URL parameters), and a fixed
     console instrumentation, so you don't hand-roll the `beforeSend` filtering
-    and `app` metadata shown below. Use raw Faro when you need something
-    `@nais/apm` `0.1.0` doesn't wrap yet — most notably
-    [trace propagation](trace-propagation.md).
+    and `app` metadata shown below. It also wraps
+    [React error boundaries and route tracking](react.md) and
+    [browser tracing](trace-propagation.md#recommended-enable-tracing-with-naisapm).
+    Use raw Faro only for the few things `@nais/apm` doesn't cover yet.
 {% endif %}
 
 ## Prerequisites

--- a/docs/observability/frontend/how-to/setup-nextjs.md
+++ b/docs/observability/frontend/how-to/setup-nextjs.md
@@ -13,9 +13,11 @@ Faro is a browser-only SDK and cannot run in React Server Components. You need a
 !!! tip "Prefer `@nais/apm` for most apps"
     Most apps should reach for the [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md)
     SDK instead of wiring up raw Faro: `init()` is zero-config, PII scrubbing is
-    built in, and you still call it from a `'use client'` entry point. This guide
-    is the lower-level path — use it when you need trace propagation, which the
-    `@nais/apm` `0.1.0` SDK doesn't wrap yet.
+    built in, and you still call it from a `'use client'` entry point. For
+    Next.js it ships a server-safe `initNaisAPMClient`, App Router route
+    tracking, and browser tracing — see
+    [React & Next.js with `@nais/apm`](react.md). This guide is the lower-level
+    raw-Faro path.
 {% endif %}
 
 ## Prerequisites

--- a/docs/observability/frontend/how-to/trace-propagation.md
+++ b/docs/observability/frontend/how-to/trace-propagation.md
@@ -12,6 +12,61 @@ By default, Faro collects browser-side traces but they're not connected to your 
 
 A few applications on Nais use this today (dp-saksbehandling-frontend, dp-brukerdialog-frontend, dp-mine-dagpenger-frontend). It's quick to set up and makes debugging cross-service issues far easier.
 
+{% if tenant() == "nav" %}
+## Recommended: enable tracing with @nais/apm
+
+If you use the [`@nais/apm`](../../apm/reference/apm-client-api.md) SDK (the
+recommended way to instrument a browser app), you don't wire up
+`TracingInstrumentation` by hand. Turn on browser tracing with a single option:
+
+```ts
+import { init } from '@nais/apm';
+
+init({ tracing: true });
+```
+
+This lazily loads `@grafana/faro-web-tracing` (it stays out of your bundle unless
+you enable it) and starts propagating W3C trace-context headers so browser spans
+join their backend traces in Tempo. Steps 2 and 3 below (CORS and a backend
+exporting to Tempo) still apply — those live on your backend, not in the SDK.
+
+### Trace-header propagation is restricted by default
+
+Distributed tracing injects `traceparent`/`tracestate` headers into outgoing
+requests. Those headers describe your internal trace topology, so they must
+never leak to third-party origins — and sending them cross-origin also trips
+CORS. `@nais/apm` therefore enforces a **non-overridable propagation floor**:
+trace headers are only ever sent to
+
+- the app's **own origin** (so same-origin API calls are traced), and
+- any **`https://*.nav.no`** host.
+
+This floor cannot be emptied or replaced — not even through the SDK's `faro`
+escape hatch. If you call a nais-owned backend on another origin, **append** it
+with `propagateExtraOrigins` (extra origins are added to the floor, never
+substituted for it):
+
+```ts
+init({
+  tracing: {
+    propagateExtraOrigins: [/https:\/\/api\.partner\.example\/.*/],
+  },
+});
+```
+
+This is the same tighten-only philosophy as the SDK's PII scrubber and session
+replay masking floor: the safe default is mandatory, and you can only add to it.
+
+Your linked browser-to-backend traces show up on the **Traces** tab of your app
+in Nais APM (and in Tempo). See
+[View traces in Nais APM](../../apm/tutorials/get-started.md#5-drill-into-traces-and-logs).
+
+![Nais APM Traces tab — span breakdowns and the trace list](../../../assets/nais-apm-service-fpsoknad-traces.png)
+
+The rest of this guide covers the **raw Faro** setup and the backend-side CORS
+and `server-timing` details that apply regardless of which SDK you use.
+{% endif %}
+
 ## How it works
 
 1. The browser sends a `traceparent` HTTP header with each API request to your backend


### PR DESCRIPTION
Documents the `@nais/apm` **v0.2.0** frontend features — first-class React support and opt-in browser tracing — now that v0.2.0 is released (nais/apm#3).

- **`@nais/apm/react`** — `ApmErrorBoundary` (render errors become fingerprinted issues), route tracking for React Router v6 and Next.js App Router, and `initNaisAPMClient` for the hydration-safe Next `instrumentation-client.ts` init.
- **Browser tracing** — `init({ tracing: true })`; distributed browser spans → Tempo with `traceparent` propagation restricted to same-origin + `*.nav.no` (never leaks to third parties; extra origins via `propagateExtraOrigins`).

Reuses existing APM screenshots; nav-gated cross-links to the APM Traces/Issues tabs.

Stacked on the frontend-alignment work (#875) — will be rebased onto `main` once that merges so it shows only the v0.2.0 delta.
