### PR TITLE
fix(svdoc): honor `.pages` conditional for section-level tenant gating

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -42,7 +42,9 @@ Nais can inject OpenTelemetry agents into your application at startup. With a fe
 
 [:dart: Get started with auto-instrumentation](../observability/how-to/auto-instrumentation.md)
 
+{% if tenant() == "nav" %}
 [:bulb: Learn more about Nais APM](apm/README.md)
+{% endif %}
 
 ## Metrics
 

--- a/svdoc/src/lib/content-store.ts
+++ b/svdoc/src/lib/content-store.ts
@@ -185,6 +185,13 @@ interface PagesFile {
 	nav?: (string | Record<string, string>)[];
 	hide?: boolean;
 	title?: string;
+	/**
+	 * Section-level tenant gating, using the same semantics as per-page
+	 * frontmatter `conditional` (see {@link shouldIncludeFile}). When present on
+	 * a directory's `.pages`, it gates the entire subtree (all pages and nav
+	 * entries) for the current tenant.
+	 */
+	conditional?: string[];
 }
 
 /**
@@ -410,6 +417,20 @@ class ContentStore {
 	 */
 	private async findMarkdownFiles(dirPath: string): Promise<string[]> {
 		const files: string[] = [];
+
+		// Section-level tenant gating. A directory's `.pages` may carry a
+		// `conditional` (e.g. `conditional: [tenant, nav]`) that gates the whole
+		// subtree for the current tenant — mirroring the mkdocs-awesome-nav
+		// `.pages` contract and the per-page frontmatter `conditional`. If it
+		// doesn't match the current tenant, skip the entire directory so its
+		// pages never enter the store (which in turn drops them from navigation
+		// and prerendering). Checked per directory as we recurse, so nested
+		// `.pages` conditionals are honoured too.
+		const dirPages = await this.readPagesFile(dirPath);
+		if (!shouldIncludeFile(dirPages?.conditional, dirPath)) {
+			log.debug(`Excluding directory "${dirPath}" - .pages conditional excludes current tenant`);
+			return files;
+		}
 
 		try {
 			const entries = await readdir(dirPath, { withFileTypes: true });


### PR DESCRIPTION
## The bug

The svdoc builder reads a directory's `.pages` file for `nav`, `hide` and `title`, but **ignores the `conditional` key**. So a section-level gate like:

```yaml
# docs/observability/apm/.pages
conditional: [tenant, nav]
```

was a **no-op**. The entire **Nais APM** section rendered for *every* tenant (`nav`, `ssb`, `test-nais`, …) instead of nav only.

Other conditional-gated sections (maskinporten, entra-id, tokenx, idporten) appeared to gate correctly only because **every page in them also carries per-page frontmatter** `conditional: [tenant, nav]`, which svdoc *does* honor via `shouldIncludeFile`. The APM section relied solely on the section-level `.pages` contract, so it leaked.

## The fix

`content-store.ts` now reads `conditional` from a directory's `.pages` and evaluates it with the **same `shouldIncludeFile` semantics** used for per-page frontmatter, during the recursive markdown scan (`findMarkdownFiles`). When the current build tenant doesn't match, the whole subtree is skipped so its pages never enter the content store — which in turn drops them from navigation, prerendering and search. The check runs per directory as we recurse, so nested `.pages` conditionals and the `...` glob are handled correctly.

This makes svdoc consistent with the existing, already-used `.pages conditional` contract rather than requiring every page in a gated section to be hand-wrapped in `{% if %}`.

The observability overview had one unguarded in-page link to the APM landing (`[Learn more about Nais APM](apm/README.md)`); it is now wrapped in `{% if tenant() == "nav" %}` so the build stays link-clean for non-nav tenants. (All the frontend/tracing APM cross-links were already guarded.)

## Before / after evidence (`mise run build nav ssb`)

| | nav | ssb (before) | ssb (after) |
|---|---|---|---|
| APM pages (`observability/apm/**`) | 16 | **16 (leaked)** | **0** |
| APM nav-link refs in output tree | 891 | **769 (leaked)** | **0** |
| maskinporten pages | 6 | 0 | 0 (no regression) |
| tracing (non-conditional) pages | 10 | 10 | 10 (unchanged) |

Both tenants build successfully; `mise run check` (prettier + eslint + svelte-check) passes with 0 errors.