### PR TITLE
docs(frontend): align frontend observability with Nais APM

### DIFF
--- a/docs/observability/frontend/README.md
+++ b/docs/observability/frontend/README.md
@@ -7,15 +7,30 @@ tags: [explanation, observability, frontend, services]
 
 # Frontend observability
 
-Nais provides frontend observability through the [Grafana Faro Web SDK][faro-web-sdk]. Faro runs in the browser and sends telemetry data (metrics, logs, errors, traces) to a collector on the Nais platform.
+Nais provides frontend observability through the [Grafana Faro Web SDK][faro-web-sdk]. Faro runs in the browser and instruments your app, shipping telemetry through the platform collector (**Alloy**) into the shared observability stores: errors and events land in **Loki**, browser spans in **Tempo**, and Core Web Vitals in **Mimir**. You then view and triage it all in [Nais APM](https://grafana.<<tenant()>>.cloud.nais.io/a/nais-apm-app).
 
 [faro-web-sdk]: https://www.npmjs.com/package/@grafana/faro-web-sdk
 
 With 95+ applications already using Faro, it's the standard way to monitor frontend applications on Nais.
 
+{% if tenant() == "nav" %}
+!!! tip "Recommended: instrument with `@nais/apm`"
+    The recommended way to add Faro to a browser app is the
+    [`@nais/apm`](../apm/reference/apm-client-api.md) SDK — a thin Faro wrapper
+    with **zero-config `init()`**, **mandatory PII scrubbing**, a required
+    `namespace`, and a fixed console instrumentation that keeps real stack
+    traces. It's the *instrument* half of Nais APM: add `@nais/apm`, then
+    **view and triage** the results on the APM [Frontend](../apm/tutorials/get-started.md#4-look-at-backend-database-and-frontend)
+    and [Issues](../apm/tutorials/get-started.md#3-check-the-issues-tab) tabs.
+
+    Start with [Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md).
+    Reach for raw Faro (the guides below) when you need something `@nais/apm`
+    doesn't cover yet — most notably [trace propagation](how-to/trace-propagation.md),
+    which the `0.1.0` SDK doesn't wrap.
+{% endif %}
+
 ## What you get
 
-![Frontend Web Vitals dashboard showing Core Web Vitals, CWV rating, and performance trends](../../assets/frontend-web-vitals-dashboard.png)
 
 - **[Core Web Vitals](https://web.dev/vitals/)** — TTFB, FCP, CLS, LCP, INP (collected automatically)
 - **Logging** — `console.info`, `console.warn`, and `console.error` messages
@@ -25,10 +40,18 @@ With 95+ applications already using Faro, it's the standard way to monitor front
 
 ## Get started
 
+{% if tenant() == "nav" %}
+1. **Recommended — errors as issues in APM:** [:dart: Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md)
+2. **Any frontend app (raw Faro):** [:dart: Set up Faro](how-to/setup-faro.md)
+3. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
+4. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
+5. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
+{% else %}
 1. **Any frontend app:** [:dart: Set up Faro](how-to/setup-faro.md)
 2. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
 3. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
 4. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
+{% endif %}
 
 ## Recommended configuration
 
@@ -62,13 +85,17 @@ On-premises clusters are not supported.
 
 ## Inspecting frontend data in Grafana
 
-Find your app in the [Nais APM](https://grafana.<<tenant()>>.cloud.nais.io/a/nais-apm-app) service list. Frontend apps show with a **Node.js** badge.
+Find your app in the [Nais APM](https://grafana.<<tenant()>>.cloud.nais.io/a/nais-apm-app/services) service inventory and open it. Browser telemetry surfaces on two tabs:
 
-![Nais APM service list showing frontend and backend apps](../../assets/frontend-apm-service-list.png)
+- **Frontend** — Core Web Vitals, pageloads, sessions, per-page performance, browser breakdown, and web-vitals attribution (what's driving LCP, INP, and CLS).
+- **Issues** — browser exceptions grouped into issues, side by side with backend errors. Filter the source to **Browser** to isolate frontend errors, then open an issue for its stack trace and impact.
 
-Go to the **Frontend** tab for Core Web Vitals, or the **Logs** tab to search exceptions and browser logs. Toggle **Include browser telemetry** to see Faro data alongside server logs.
 
-![APM Logs tab filtered by exceptions, showing browser telemetry](../../assets/frontend-apm-logs.png)
+![Nais APM Issues tab filtered to browser-sourced exceptions](../../assets/nais-apm-service-navno-issues-frontend.png)
+
+{% if tenant() == "nav" %}
+For a full tour of the tabs, see [Get started with Nais APM](../apm/tutorials/get-started.md); for capturing errors from your own code, see [Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md).
+{% endif %}
 
 For deeper analysis, use the [Explore view](https://grafana.<<tenant()>>.cloud.nais.io/explore) with one of the Loki data sources. Here are some useful queries:
 
@@ -103,6 +130,10 @@ For local development, check out the [tracing demo repository](https://github.co
 
 ## Further reading
 
+{% if tenant() == "nav" %}
+- [Nais APM](../apm/README.md) — view and triage the telemetry you instrument here
+- [`@nais/apm` API reference](../apm/reference/apm-client-api.md) — the recommended SDK's full API
+{% endif %}
 - [Grafana Faro Web SDK docs](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/)
 - [Grafana Faro Web SDK on npm](https://www.npmjs.com/package/@grafana/faro-web-sdk)
 - [Grafana Faro Web SDK changelog](https://github.com/grafana/faro-web-sdk/blob/main/CHANGELOG.md)

--- a/docs/observability/frontend/how-to/setup-faro.md
+++ b/docs/observability/frontend/how-to/setup-faro.md
@@ -7,6 +7,18 @@ tags: [how-to, observability, frontend]
 
 Add [Grafana Faro](https://www.npmjs.com/package/@grafana/faro-web-sdk) to a frontend application running on Nais.
 
+{% if tenant() == "nav" %}
+!!! tip "Prefer `@nais/apm` for most apps"
+    This guide covers **raw Faro**, the lower-level foundation. For most browser
+    apps the recommended path is the [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md)
+    SDK — a thin Faro wrapper that gives you zero-config `init()`, **built-in PII
+    scrubbing** (fødselsnummer, emails, and token URL parameters), and a fixed
+    console instrumentation, so you don't hand-roll the `beforeSend` filtering
+    and `app` metadata shown below. Use raw Faro when you need something
+    `@nais/apm` `0.1.0` doesn't wrap yet — most notably
+    [trace propagation](trace-propagation.md).
+{% endif %}
+
 ## Prerequisites
 
 - A frontend application deployed on Nais (GCP only; on-premises is not supported)
@@ -307,9 +319,10 @@ Without this, the browser blocks Faro's requests to the collector. See [Troubles
 
 Faro captures console output, errors, and HTTP request URLs automatically. Make sure you don't leak sensitive data:
 
-- **Never log** fødselsnummer, tokens, passwords, or other PII to the console
-- **Watch URLs** — query parameters and path segments may contain identifiers
-- **Watch form input** — don't send user input as custom events without redacting
+- **Never log** fødselsnummer, emails, names, tokens, passwords, or any other personal identifier to the console or into telemetry. Nav operates on identities but must not log them.
+- **Use opaque identifiers** — when you need to correlate a user or session, use a hashed or otherwise opaque id, never a fødselsnummer, email, or other ident.
+- **Watch URLs** — query parameters and path segments may contain identifiers or tokens.
+- **Watch form input** — don't send user input as custom events without redacting.
 
 Use the `beforeSend` hook to filter or redact telemetry:
 
@@ -336,6 +349,16 @@ initializeFaro({
   },
 });
 ```
+
+{% if tenant() == "nav" %}
+!!! info "`@nais/apm` scrubs this for you"
+    [`@nais/apm`](../../apm/reference/apm-client-api.md#privacy-pii-scrubbing)
+    runs a mandatory scrubber on every outgoing signal — fødselsnummer → `[fnr]`,
+    emails → `[email]`, and token-bearing URL parameters → `[redacted]` — after
+    your own `beforeSend`. It's a best-effort safety net, not a GDPR guarantee:
+    the rule above still stands — don't put personal data in telemetry in the
+    first place.
+{% endif %}
 
 ## Local development
 
@@ -366,3 +389,6 @@ These `navikt` repositories use Faro with React Router:
 - [Set up Faro with Next.js App Router](setup-nextjs.md)
 - [Connect frontend traces to backend spans](trace-propagation.md)
 - [Learn how sourcemap deobfuscation works](sourcemaps.md)
+{% if tenant() == "nav" %}
+- [View and triage your frontend errors in Nais APM](../../apm/tutorials/get-started.md)
+{% endif %}

--- a/docs/observability/frontend/how-to/setup-nextjs.md
+++ b/docs/observability/frontend/how-to/setup-nextjs.md
@@ -9,6 +9,15 @@ Set up [Grafana Faro](https://www.npmjs.com/package/@grafana/faro-web-sdk) in a 
 
 Faro is a browser-only SDK and cannot run in React Server Components. You need a `'use client'` component that initializes Faro on the client side.
 
+{% if tenant() == "nav" %}
+!!! tip "Prefer `@nais/apm` for most apps"
+    Most apps should reach for the [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md)
+    SDK instead of wiring up raw Faro: `init()` is zero-config, PII scrubbing is
+    built in, and you still call it from a `'use client'` entry point. This guide
+    is the lower-level path — use it when you need trace propagation, which the
+    `@nais/apm` `0.1.0` SDK doesn't wrap yet.
+{% endif %}
+
 ## Prerequisites
 
 - A Next.js application using the App Router, deployed on Nais
@@ -48,7 +57,8 @@ export default function Faro({ collectorUrl }: { collectorUrl?: string }) {
         url: collectorUrl || 'https://telemetry.nav.no/collect',
         paused: window.location.hostname === 'localhost',
         app: {
-          name: 'my-app',
+          name: 'my-app',       // required — must match metadata.name in nais.yaml
+          namespace: 'my-team',  // required — must match metadata.namespace in nais.yaml
         },
         instrumentations: [
           ...getWebInstrumentations(),
@@ -81,7 +91,8 @@ export default function Faro({ collectorUrl }: { collectorUrl?: string }) {
         url: collectorUrl || '<<tenant_url("telemetry.external.prod", "collect")>>',
         paused: window.location.hostname === 'localhost',
         app: {
-          name: 'my-app',
+          name: 'my-app',       // required — must match metadata.name in nais.yaml
+          namespace: 'my-team',  // required — must match metadata.namespace in nais.yaml
         },
         instrumentations: [
           ...getWebInstrumentations(),

--- a/docs/observability/frontend/how-to/sourcemaps.md
+++ b/docs/observability/frontend/how-to/sourcemaps.md
@@ -101,3 +101,7 @@ Common reasons for failure:
 4. The stack trace should show your original file names and line numbers
 
 If you see minified output instead, check [Troubleshooting](../reference/troubleshooting.md#sourcemaps-not-resolving).
+
+{% if tenant() == "nav" %}
+Resolved stack traces also appear on each error in the Nais APM [Issues tab](../../apm/tutorials/get-started.md#3-check-the-issues-tab), with your own code highlighted. Deobfuscation is server-side, so it works the same whether you instrument with raw Faro or [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md#5-ship-readable-stack-traces).
+{% endif %}

--- a/docs/observability/frontend/how-to/trace-propagation.md
+++ b/docs/observability/frontend/how-to/trace-propagation.md
@@ -7,7 +7,8 @@ tags: [how-to, observability, frontend, tracing]
 
 By default, Faro collects browser-side traces but they're not connected to your backend spans in Tempo. With trace propagation, you get end-to-end visibility: a single trace that follows a user action from the browser through your backend services.
 
-![Service topology showing dp-saksbehandling-frontend connected to backend services via traces](../../../assets/frontend-trace-topology.png)
+![Nais APM Traces tab — span breakdowns and the trace list](../../../assets/nais-apm-service-fpsoknad-traces.png)
+![Service topology showing a frontend connected to backend services via traces](../../../assets/frontend-trace-topology.png)
 
 A few applications on Nais use this today (dp-saksbehandling-frontend, dp-brukerdialog-frontend, dp-mine-dagpenger-frontend). It's quick to set up and makes debugging cross-service issues far easier.
 
@@ -150,6 +151,9 @@ export function middleware(request: NextRequest) {
 
 ## Related
 
+{% if tenant() == "nav" %}
+- [View traces in Nais APM](../../apm/tutorials/get-started.md#5-drill-into-traces-and-logs) — search and break down your linked browser-to-backend traces
+{% endif %}
 - [Backend context propagation](../../tracing/how-to/context-propagation.md) — how to propagate traces between backend services
 - [Correlate traces and logs](../../tracing/how-to/correlate-traces-logs.md) — connect traces with structured logs
 - [Troubleshooting](../reference/troubleshooting.md) — common CORS and CSP issues

--- a/docs/observability/frontend/reference/auto-configuration.md
+++ b/docs/observability/frontend/reference/auto-configuration.md
@@ -14,6 +14,16 @@ spec:
       mountPath: /usr/share/nginx/html/js/nais.js
 ```
 
+{% if tenant() == "nav" %}
+!!! tip "`@nais/apm` reads these automatically"
+    If you instrument with [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md),
+    you don't consume this file by hand. `init()` resolves the app name, version,
+    environment, and collector URL from Nais meta tags in your served HTML or from
+    the build-time `NAIS_*` environment variables — see
+    [Configuration resolution](../../apm/reference/apm-client-api.md#configuration-resolution).
+    This reference matters when you wire up **raw Faro** yourself.
+{% endif %}
+
 ## Generated JavaScript file
 
 The platform creates a JavaScript file at the specified `mountPath` with this structure:


### PR DESCRIPTION
Aligns the frontend-observability docs with Nais APM.

The Nais APM doc section itself is already on `main` (added via #871), and the section's tenant-gating fix landed via #874. So the delta here is purely the **frontend-observability alignment** (6 files):

- Positions **`@nais/apm`** as the recommended browser SDK, with raw `@grafana/faro-web-sdk` kept as the lower-level path.
- Bidirectionally cross-links the frontend docs with the nav-gated Nais APM section — *instrument your frontend here → view/triage it in Nais APM*.
- Refreshes the pipeline description (Faro → Alloy → Loki/Tempo/Mimir) and drops commercial-product comparisons.
- Strengthens PII guidance (opaque/hashed ids, never fnr/emails/idents) and reuses existing APM screenshots (Traces, browser-filtered Issues).

Nav-only cross-links use `{% if tenant() == "nav" %}`. Builds green for both nav and ssb.
