### PR TITLE
docs: @nais/apm framework quickstarts (Next.js, React+Vite)

### DIFF
--- a/docs/observability/frontend/README.md
+++ b/docs/observability/frontend/README.md
@@ -42,10 +42,12 @@ With 95+ applications already using Faro, it's the standard way to monitor front
 
 {% if tenant() == "nav" %}
 1. **Recommended — errors as issues in APM:** [:dart: Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md)
-2. **Any frontend app (raw Faro):** [:dart: Set up Faro](how-to/setup-faro.md)
-3. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
-4. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
-5. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
+2. **Next.js (App Router or Pages Router):** [:simple-nextdotjs: Next.js quickstart with `@nais/apm`](how-to/quickstart-nextjs.md)
+3. **React SPA + Vite:** [:simple-react: React + Vite quickstart with `@nais/apm`](how-to/quickstart-react-vite.md)
+4. **Coming from Sentry?** [Migrate from Sentry to `@nais/apm`](how-to/migrate-from-sentry.md)
+5. **Need raw Faro** (e.g. trace propagation on `0.1.0`)**?** [Set up Faro](how-to/setup-faro.md) · [Next.js with raw Faro](how-to/setup-nextjs.md)
+6. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
+7. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
 {% else %}
 1. **Any frontend app:** [:dart: Set up Faro](how-to/setup-faro.md)
 2. **Next.js App Router:** [:simple-nextdotjs: Set up Faro with Next.js](how-to/setup-nextjs.md)
@@ -117,6 +119,20 @@ Traces are available from data sources ending with `-tempo`. Use [TraceQL](../tr
 For local development, check out the [tracing demo repository](https://github.com/nais/tracing-demo) and run `docker-compose up`. This gives you a local Grafana, Loki, and Tempo stack to test against. See the README in that repository for details.
 
 ## Guides
+
+{% if tenant() == "nav" %}
+The recommended path is the `@nais/apm` SDK. Pick the quickstart for your
+framework:
+
+| Framework quickstart | Description |
+| -------------------- | ----------- |
+| [Next.js with `@nais/apm`](how-to/quickstart-nextjs.md) | App Router and Pages Router: client init, error boundary, route tracking, tracing |
+| [React + Vite with `@nais/apm`](how-to/quickstart-react-vite.md) | React SPA: entry-point init, error boundary, React Router tracking |
+| [Migrate from Sentry](how-to/migrate-from-sentry.md) | Move an existing `@sentry/*` app onto `@nais/apm` |
+
+The raw-Faro guides below are the lower-level path — reach for them when you need
+something `@nais/apm` doesn't wrap yet (most notably [trace propagation](how-to/trace-propagation.md)).
+{% endif %}
 
 | Guide | Description |
 | ----- | ----------- |

--- a/docs/observability/frontend/how-to/migrate-from-sentry.md
+++ b/docs/observability/frontend/how-to/migrate-from-sentry.md
@@ -1,0 +1,415 @@
+---
+title: Migrate from Sentry to @nais/apm
+description: >-
+  Move a frontend app off @sentry/* and onto the @nais/apm SDK — a clean, full
+  migration with a concept map, a copy-pasteable recipe, and an honest list of
+  what is different and what is not supported yet.
+tags: [how-to, observability, frontend, apm, sentry, migration]
+conditional: [tenant, nav]
+---
+
+# Migrate from Sentry to `@nais/apm`
+
+This guide takes a frontend app off Sentry (`@sentry/browser`, `@sentry/react`,
+`@sentry/nextjs`, …) and onto [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md),
+the Nais browser telemetry SDK. Your errors stop going to `sentry.gc.nav.no` and
+start showing up as issues in [Nais APM](../../apm/README.md), on your team's own
+Grafana stack.
+
+## Who this is for
+
+You're on this page if your app calls `Sentry.init` and friends today. Many of
+these apps also already run [Grafana Faro](../../frontend/README.md) alongside
+Sentry — `@nais/apm` is a thin, opinionated wrapper over Faro with a Sentry-like
+developer experience, so if that's you, this migration also collapses two SDKs
+into one.
+
+The end state is **idiomatic `@nais/apm`** with Sentry **fully removed**: no
+`@sentry/*` dependency, no DSN, no `withSentryConfig`, no `SENTRY_AUTH_TOKEN`.
+
+!!! info "Not a compatibility shim"
+    There is deliberately no `Sentry`-named drop-in. `@nais/apm` gives you the
+    same *shapes* (`captureException`, `setUser`, an error boundary) under its own
+    names, so you migrate call sites once and delete Sentry for good. A handful of
+    Sentry features have no equivalent yet — see
+    [What's different](#whats-different-read-this) before you start.
+
+!!! note "Status: pre-release"
+    `@nais/apm` is pre-1.0. Pin an exact version and read the
+    [CHANGELOG](https://github.com/nais/apm/blob/main/CHANGELOG.md) before
+    upgrading. This guide targets `0.2.0`.
+
+## Concept map
+
+| Sentry | `@nais/apm` | Notes |
+| ------ | ----------- | ----- |
+| `Sentry.init({ dsn, ... })` | [`init()`](../../apm/reference/apm-client-api.md#initoptions) / [`initNaisAPMClient()`](../../apm/tutorials/track-frontend-errors.md#3-initialize-zero-config) | Zero-config on Nais — **no DSN**. App name, version, environment, collector URL all resolve automatically. |
+| `Sentry.captureException(e)` | `captureException(e, { context, fingerprint })` | Returns **`void`** — no event ID (see [What's different](#no-event-id-from-captureexception)). |
+| `Sentry.captureMessage(m, level)` | `captureMessage(m, level)` | Same severity levels. |
+| `Sentry.setUser({ id })` | `setUser({ id })` | **PII is dropped.** Opaque/hashed ids only — [see below](#setuser-drops-pii). |
+| `Sentry.setUser(null)` | `clearUser()` | On logout. |
+| `Sentry.setTag(k, v)` | `setTag(k, v)` | Approximation — rides as context, **not** an indexed label. |
+| `Sentry.setContext(name, obj)` | `setContext(name, obj)` | Flattened as `name.key`; `setContext(name, null)` removes it. |
+| `Sentry.setExtra(k, v)` | `setContext(name, obj)` | No `setExtra` — fold extras into a named context. |
+| `Sentry.ErrorBoundary` | [`ApmErrorBoundary`](../../apm/reference/apm-client-api.md) | From `@nais/apm/react`. |
+| `Sentry.withErrorBoundary(C)` | `withApmErrorBoundary(C)` | HOC form. |
+| React Router integration | `enableApmReactRouterV6()` + `<ApmRoutes>` | React Router v6. |
+| `Sentry.captureRouterTransitionStart` (Next.js) | `useApmRouteTracking()` hook | Next.js App Router. |
+| `browserTracingIntegration` / `tracesSampleRate` | `init({ tracing: true })` | On/off; auto-instruments fetch/XHR. See [trace propagation](trace-propagation.md). |
+| `replayIntegration()` | `init({ sessionReplay: { enabled: true } })` | Defaults to the **events tier** (no DOM) — [see below](#replay-defaults-to-the-events-tier). |
+| `ignoreErrors: [...]` | `init({ ignoreErrors: [...] })` | Appended to `DEFAULT_IGNORE_ERRORS` (extensions, ResizeObserver, `Script error.`). |
+| `beforeSend(event)` | `init({ beforeSend })` | Runs **before** the mandatory PII scrubber. |
+| `@sentry/webpack-plugin` / `withSentryConfig` sourcemap upload | *(nothing to configure)* | Stack traces resolve **server-side** from the CDN — [sourcemaps](sourcemaps.md). |
+| `Sentry.showReportDialog` / User Feedback | `captureFeedback()` | Programmatic, **preview/internal-pilot only**, no built-in widget. |
+| Sentry Issues UI | [Issues tab](../../apm/tutorials/get-started.md#3-check-the-issues-tab) in Nais APM | Different triage model — [triage an issue](../../apm/how-to/triage-an-issue.md). |
+| Sentry Alerts | [Grafana alerts](../../apm/how-to/create-alerts.md) | Built from templates, delivered via Grafana contact points. |
+| `release: process.env.…` | `version` (auto) | Resolved from `GITHUB_SHA` / image tag; joins deploy markers. |
+
+## Step-by-step recipe
+
+### 1. Remove Sentry
+
+Drop every `@sentry/*` package and its config from `package.json`:
+
+```sh
+npm uninstall @sentry/browser @sentry/react @sentry/nextjs @sentry/webpack-plugin
+```
+
+Delete the DSN and auth-token wiring while you're here — you won't need them:
+
+- `NEXT_PUBLIC_SENTRY_DSN` / `SENTRY_DSN` env and secrets
+- `SENTRY_AUTH_TOKEN` (CI secret used for sourcemap upload)
+- any `sentry.client.config.*` / `sentry.server.config.*` / `sentry.edge.config.*`
+
+### 2. Add `@nais/apm`
+
+`@nais/apm` is published to the GitHub Package Registry. Configure the registry
+(one-time, in `.npmrc`) and install — the full steps are in
+[Track frontend errors](../../apm/tutorials/track-frontend-errors.md#1-configure-the-package-registry):
+
+```sh
+npm install @nais/apm@0.2.0
+```
+
+The React helpers (error boundary, route tracking, Next.js client init) live in
+the `@nais/apm/react` entry point.
+
+### 3. Swap `Sentry.init` → `init()`
+
+There is no DSN and, on Nais, nothing to configure — `init()` reads the app name,
+version, environment, team, and collector URL from the Nais
+[meta tags / `NAIS_*` env](../../apm/reference/apm-client-api.md#configuration-resolution).
+
+=== "React / Vite"
+
+    **Before** (`initSentry.ts`, real navikt shape):
+
+    ```ts
+    import * as Sentry from '@sentry/browser';
+
+    Sentry.init({
+      dsn: import.meta.env.VITE_SENTRY_DSN,
+      release: import.meta.env.VITE_SENTRY_RELEASE,
+      environment: globalThis.location.hostname,
+      integrations: [Sentry.breadcrumbsIntegration({ console: false })],
+      ignoreErrors: ['TypeError: Failed to fetch'],
+      beforeSend: (event) => (isNoise(event) ? null : event),
+    });
+    ```
+
+    **After** (`main.tsx`):
+
+    ```ts
+    import { init } from '@nais/apm';
+
+    init({
+      // app / version / environment / namespace all resolve from Nais — omit them.
+      ignoreErrors: [/Failed to fetch/],
+      beforeSend: (item) => (isNoise(item) ? null : item),
+    });
+    ```
+
+=== "Next.js (App Router)"
+
+    **Before** (`instrumentation-client.ts`, real navikt shape):
+
+    ```ts
+    import * as Sentry from '@sentry/nextjs';
+
+    Sentry.init({
+      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      release: process.env.NEXT_PUBLIC_APP_VERSION,
+      allowUrls: ['arbeidsplassen.nav.no'],
+      ignoreErrors: ['TypeError: Failed to fetch'],
+      beforeSend(event, hint) { return isNoise(hint) ? null : event; },
+    });
+
+    export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+    ```
+
+    **After** (`instrumentation-client.ts`):
+
+    ```ts
+    import { initNaisAPMClient } from '@nais/apm/react';
+
+    initNaisAPMClient({
+      namespace: 'my-team', // or resolved from a <meta name="nais-team"> tag / NAIS_TEAM
+      ignoreErrors: [/Failed to fetch/],
+      tracing: true, // optional — see step 5
+    });
+    ```
+
+    `initNaisAPMClient` no-ops on the server and is idempotent under React Strict
+    Mode, so it's safe to import from `instrumentation-client.ts` (Next 15+) or a
+    Pages Router `_app.tsx`. Route tracking replaces `onRouterTransitionStart` —
+    see step 4.
+
+!!! tip "`beforeSend` semantics changed"
+    In Sentry your `beforeSend` was the last word. In `@nais/apm` it runs **first**;
+    the mandatory PII scrubber always runs **last** and cannot be removed (only
+    `dangerouslyDisablePiiScrubbing: true` disables it, and then your team owns the
+    GDPR consequences). You usually no longer need `allowUrls` / manual noise
+    filters for extensions and `ResizeObserver` — those are in `DEFAULT_IGNORE_ERRORS`.
+
+### 4. Replace the error boundary and route tracking
+
+**Error boundary** — swap `Sentry.ErrorBoundary` for `ApmErrorBoundary`:
+
+```tsx
+// Before
+import * as Sentry from '@sentry/react';
+<Sentry.ErrorBoundary fallback={<TekniskFeilSide />}>
+  <App />
+</Sentry.ErrorBoundary>
+
+// After
+import { ApmErrorBoundary } from '@nais/apm/react';
+<ApmErrorBoundary fallback={<TekniskFeilSide />}>
+  <App />
+</ApmErrorBoundary>
+```
+
+`ApmErrorBoundary` reports through `captureException` exactly once, so caught
+render errors get the SDK's fingerprint/context pipeline. The `withApmErrorBoundary(Component, props?)`
+HOC mirrors `Sentry.withErrorBoundary`. The `fallback` can also be a render prop
+`(error, resetError) => node`.
+
+**Route tracking:**
+
+=== "React Router v6"
+
+    Call once after `init()`, passing your own `react-router-dom` exports, then
+    render `<ApmRoutes>` where you rendered `<Routes>`:
+
+    ```tsx
+    import {
+      createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType,
+    } from 'react-router-dom';
+    import { enableApmReactRouterV6, ApmRoutes } from '@nais/apm/react';
+
+    enableApmReactRouterV6({
+      createRoutesFromChildren, matchRoutes, Routes, useLocation, useNavigationType,
+    });
+
+    // <ApmRoutes> instead of <Routes>
+    ```
+
+=== "Next.js (App Router)"
+
+    Use the hook in a client component and mount it once in your layout:
+
+    ```tsx
+    'use client';
+    import { usePathname, useSearchParams } from 'next/navigation';
+    import { useApmRouteTracking } from '@nais/apm/react';
+
+    export function ApmRouteTracker() {
+      useApmRouteTracking(usePathname(), useSearchParams());
+      return null;
+    }
+    ```
+
+!!! warning "React Router v5/v7 and data routers are not wired yet"
+    Route tracking currently covers **React Router v6** and the **Next.js App
+    Router** only. See [What's different](#not-yet-supported).
+
+### 5. Tracing (optional)
+
+If you used `browserTracingIntegration` / `tracesSampleRate`, enable tracing with
+one flag. `@grafana/faro-web-tracing` is lazily loaded so it stays out of your
+bundle unless you turn it on:
+
+```ts
+init({ tracing: true });
+```
+
+Trace headers are propagated to your own origin and `*.nav.no` backends by
+default (a non-overridable security floor). Add more with
+`init({ tracing: { propagateExtraOrigins: ['https://api.partner.example'] } })`.
+Your backend still needs to allow the `traceparent` CORS header — see
+[frontend-to-backend trace propagation](trace-propagation.md).
+
+### 6. Delete sourcemap upload
+
+Remove the entire `@sentry/webpack-plugin` / `withSentryConfig` sourcemap-upload
+step and the `SENTRY_AUTH_TOKEN` it needed:
+
+```ts
+// next.config.ts — DELETE the withSentryConfig wrapper
+const nextConfig = withSentryConfig(baseConfig, {
+  org: 'nav',
+  project: 'my-app',
+  sentryUrl: 'https://sentry.gc.nav.no/',
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+});
+export default nextConfig; // -> export default baseConfig;
+```
+
+There is **nothing to replace it with**. The Nais telemetry collector resolves
+minified stack traces **server-side** by fetching your `.map` files from the CDN
+(`cdn.nav.no`) at read time. You only need to *emit* sourcemaps and deploy them
+alongside your bundle — no upload, no auth token. Follow
+[Sourcemap deobfuscation](sourcemaps.md) for the build settings and the CDN
+requirement.
+
+### 7. Replace Sentry Replay
+
+If you ran `replayIntegration()`, use `sessionReplay`:
+
+```ts
+init({ sessionReplay: { enabled: true, mode: 'on-error' } });
+```
+
+This defaults to the **events tier** — a DOM-free interaction timeline, safe by
+construction. It is **not** a like-for-like replacement for Sentry's full DOM
+recording; opting into DOM capture is a deliberate, personvernombud-gated
+decision. Read [What's different](#replay-defaults-to-the-events-tier) and
+[Enable session replay](../../apm/how-to/enable-session-replay.md) before you
+turn anything on.
+
+### 8. Move alerting to Grafana
+
+Sentry alert rules don't come across. Recreate them as
+[Grafana alerts from Nais APM templates](../../apm/how-to/create-alerts.md)
+(error rate, exception spike, new exceptions, web vitals) — delivered through
+your team's Grafana contact points.
+
+## What's different (read this)
+
+This is the honest section. A clean migration means understanding where
+`@nais/apm` is deliberately *not* Sentry.
+
+### No event ID from `captureException`
+
+`Sentry.captureException` returns an event ID; `@nais/apm`'s returns `void` (a
+Faro limitation). There is **no `lastEventId()`**. If any code relied on the
+returned id — to show a reference code to the user, or to link a crash-report
+dialog to an event — that pattern doesn't carry over. Use your own correlation id
+(e.g. a `crypto.randomUUID()` you also attach as `context`) instead.
+
+### `setUser` drops PII
+
+This is the personvern rule, and it is enforced in code — call it out on your
+team before you migrate. NAV telemetry lands in a **shared Loki instance that
+every team can read**, so identities must never reach it. `setUser`:
+
+- **drops** any `id` / `username` / `attributes` value that looks like a
+  fødselsnummer, email, or raw NAV ident (and warns once);
+- drops the `email` field **unconditionally** (it is deprecated).
+
+Pass an **opaque, non-identifying** id — a salted hash, never a raw ident:
+
+```ts
+// Before (Sentry) — teams already hash, keep doing it:
+Sentry.setUser({ id: hash(fnr) });
+
+// After (@nais/apm) — same idea, PII is a hard floor:
+setUser({ id: hash(fnr) }); // an ident/email/fnr passed here is silently dropped
+```
+
+The transport also runs a mandatory PII scrubber over every signal (fnr → `[fnr]`,
+email → `[email]`, token URL params → `[redacted]`). It's a safety net, not a
+GDPR guarantee — don't put personal data in error messages in the first place.
+
+### Issues live in the Grafana Issues tab
+
+Errors show up in the **Issues tab** of your service in
+[Nais APM](<<tenant_url("grafana", "a/nais-apm-app/services")>>), not in
+Sentry's issue stream. The [triage model](../../apm/how-to/triage-an-issue.md) is
+different: Resolve / Ignore / Assign is shared team state stored in Grafana
+annotations, a resolved issue that recurs after a newer deploy is flagged
+**Regressed**, and you can personally **mute** without touching shared state.
+Grouping is driven by [fingerprinting](../../apm/reference/issues-model.md) — pass
+a `fingerprint` to `captureException` to control it, the same idea as Sentry's
+`fingerprint`.
+
+### Source maps resolve server-side
+
+No `sentry-cli`, no `@sentry/webpack-plugin`, no upload step, no `SENTRY_AUTH_TOKEN`.
+Deobfuscation happens in the collector by fetching `.map` files from `cdn.nav.no`.
+The catch: it **only works for bundles served from the CDN**. A purely
+server-rendered app that serves its own JS from the pod won't get resolved stack
+traces unless it also ships static assets to the CDN. See
+[Sourcemaps](sourcemaps.md#requirements).
+
+### Alerts are Grafana alerts
+
+Sentry's alert rules, notification integrations, and issue-owner routing don't
+migrate. Alerting is Grafana alerting, seeded from
+[Nais APM templates](../../apm/how-to/create-alerts.md). Note there's **no
+SLO/burn-rate template yet**.
+
+### Replay defaults to the events tier
+
+Sentry Replay records the DOM. `@nais/apm`'s `sessionReplay: { enabled: true }`
+defaults to the **events tier**: a lightweight interaction timeline (navigation,
+clicks, coarse scroll) with **no DOM node tree** — structurally nothing to leak.
+Full masked-DOM recording exists (`tier: 'dom'`) but pushes DOM into shared Loki
+and is **gated on the personvernombud process** — do not enable it on
+citizen-facing apps without sign-off. Replay is a **preview** feature and off by
+default.
+
+### Not yet supported
+
+These Sentry features have **no `@nais/apm` equivalent** at `0.2.0`. State this
+plainly to your team so nobody is surprised mid-migration:
+
+| Sentry feature | Status in `@nais/apm` |
+| -------------- | --------------------- |
+| `addBreadcrumb()` / `beforeBreadcrumb` | **Not supported.** No manual breadcrumb API. The events-tier replay timeline captures interactions automatically, but you can't push custom breadcrumbs. |
+| Manual spans / performance — `startSpan`, `startInactiveSpan`, `startTransaction` | **Not supported.** Tracing is on/off auto-instrumentation of fetch/XHR only; there is no manual span/transaction API. |
+| Scopes — `withScope`, `configureScope`, `getCurrentScope` | **Not supported.** Context set via `setTag` / `setContext` is module-global; there's no per-scope isolation. |
+| `setExtra` / `setExtras` / `setTags` (plural) | **Not supported.** Use `setTag` (single) and `setContext`. |
+| `lastEventId()` | **Not supported** — `captureException` returns `void`. |
+| `showReportDialog()` / crash-report modal | **Not supported.** `captureFeedback()` is programmatic and preview/internal-pilot only — no built-in widget. |
+| Profiling, release-health/session tracking, attachments | **Not supported.** |
+| React Router v5 / v7 / data routers | **Not yet** — v6 and Next.js App Router only. |
+
+If you depend on one of these, note it before you delete Sentry, and track it
+against the [`@nais/apm` CHANGELOG](https://github.com/nais/apm/blob/main/CHANGELOG.md).
+`setTag` also differs subtly: Faro has no indexed tag concept, so a tag rides
+along as **context** on every capture rather than as a searchable label.
+
+## Migration checklist
+
+- [ ] Removed every `@sentry/*` dependency from `package.json`.
+- [ ] Deleted DSN env/secrets (`*_SENTRY_DSN`) and `SENTRY_AUTH_TOKEN`.
+- [ ] Deleted `sentry.*.config.*` files and the `withSentryConfig` wrapper.
+- [ ] Added `@nais/apm` (registry configured in `.npmrc`, exact version pinned).
+- [ ] Swapped `Sentry.init` → `init()` / `initNaisAPMClient()`.
+- [ ] Replaced `Sentry.ErrorBoundary` → `ApmErrorBoundary` (and `withErrorBoundary` → `withApmErrorBoundary`).
+- [ ] Wired route tracking (`enableApmReactRouterV6` + `<ApmRoutes>`, or `useApmRouteTracking`).
+- [ ] Migrated `captureException` / `captureMessage` / `setTag` / `setContext` call sites.
+- [ ] Confirmed `setUser` only ever receives an **opaque/hashed** id — no fnr, email, or ident.
+- [ ] Enabled `tracing: true` if you used `browserTracingIntegration` (and CORS allows `traceparent`).
+- [ ] Removed sourcemap upload; verified `.map` files ship to the CDN ([sourcemaps](sourcemaps.md)).
+- [ ] Recreated alerts as [Grafana alerts](../../apm/how-to/create-alerts.md).
+- [ ] Audited [not-yet-supported](#not-yet-supported) features and logged any gaps.
+- [ ] Deployed, triggered a test error, and confirmed it appears in the [Issues tab](../../apm/tutorials/track-frontend-errors.md#6-see-your-errors-as-issues).
+
+## Related
+
+- [Track frontend errors with `@nais/apm`](../../apm/tutorials/track-frontend-errors.md) — the from-scratch tutorial.
+- [`@nais/apm` API reference](../../apm/reference/apm-client-api.md) — every export and option.
+- [Sourcemap deobfuscation](sourcemaps.md) — how stack traces resolve.
+- [Triage an issue](../../apm/how-to/triage-an-issue.md) · [Create alerts](../../apm/how-to/create-alerts.md)

--- a/docs/observability/frontend/how-to/quickstart-nextjs.md
+++ b/docs/observability/frontend/how-to/quickstart-nextjs.md
@@ -1,0 +1,311 @@
+---
+title: Next.js quickstart with @nais/apm
+description: >-
+  Instrument a Next.js app with @nais/apm — client init, an error boundary,
+  route tracking, and opt-in tracing. Covers both the App Router and the Pages
+  Router.
+tags: [how-to, observability, frontend, apm, next.js]
+conditional: [tenant, nav]
+---
+
+# Next.js quickstart with `@nais/apm`
+
+Instrument a Next.js frontend with [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md),
+the Nais browser telemetry SDK, and see your errors as issues in
+[Nais APM](../../apm/README.md). Next.js is the most common frontend framework on
+Nais, so this is the fast path: client init, a React error boundary, route
+tracking, and — if you want it — distributed tracing.
+
+This guide covers both routers:
+
+- **[App Router](#app-router)** (`app/`) — the default since Next.js 13 and what
+  most Next apps here use. Start here.
+- **[Pages Router](#pages-router)** (`pages/`) — the `_app.tsx` variant, including
+  the Nais golden-path template. See the [Pages Router section](#pages-router) for
+  the differences.
+
+!!! note "Status: pre-release"
+    `@nais/apm` is pre-1.0. Pin an exact version and read the
+    [CHANGELOG](https://github.com/nais/apm/blob/main/CHANGELOG.md) before
+    upgrading. This guide targets `0.2.0`.
+
+!!! tip "Migrating off Sentry?"
+    If your app calls `Sentry.init` today, follow
+    [Migrate from Sentry to `@nais/apm`](migrate-from-sentry.md) instead — it maps
+    every `@sentry/nextjs` call site to its `@nais/apm` equivalent and lists what's
+    different.
+
+## Prerequisites
+
+- A Next.js application (15 or newer for `instrumentation-client.ts`; the Pages
+  Router pattern works on older versions too) deployed on Nais.
+- The `@nais` package registry configured in your `.npmrc`. This is a one-time
+  setup — follow
+  [step 1 of Track frontend errors](../../apm/tutorials/track-frontend-errors.md#1-configure-the-package-registry).
+
+## Install
+
+```sh
+pnpm add @nais/apm@0.2.0
+# or: npm install @nais/apm@0.2.0 / yarn add @nais/apm@0.2.0
+```
+
+The React helpers used below — `initNaisAPMClient`, `ApmErrorBoundary`,
+`useApmRouteTracking` — live in the `@nais/apm/react` entry point.
+
+## App Router
+
+### 1. Initialize the client
+
+On Next.js 15+, the client instrumentation hook `instrumentation-client.ts` runs
+once, early, in the browser — the ideal place to initialize telemetry. Create it
+at your project root (next to `next.config.js`):
+
+```ts
+// instrumentation-client.ts
+import { initNaisAPMClient } from '@nais/apm/react';
+
+initNaisAPMClient({
+  namespace: 'my-team', // your Nais team — see the note below
+});
+```
+
+`initNaisAPMClient` no-ops on the server (`typeof window === 'undefined'`) and is
+idempotent, so it's safe under React Strict Mode's double-invoke and any repeated
+imports. Everything else — app name, version, environment, and the collector URL
+— [resolves automatically](../../apm/reference/apm-client-api.md#configuration-resolution)
+from Nais meta tags or `NAIS_*` build env. On `localhost`, where no collector
+resolves, it sends **nothing** and echoes every signal to the console.
+
+!!! info "`namespace` is your team"
+    `namespace` is the Nais team that owns the app (its Kubernetes namespace).
+    Nais APM attributes all telemetry by team, so it's effectively required. Pass
+    it explicitly as shown, or let it resolve from a
+    `<meta name="nais-team" content="my-team">` tag or the `NAIS_TEAM` env — then
+    you can drop the option entirely.
+
+### 2. Add an error boundary
+
+Wrap your app in `ApmErrorBoundary` in the root layout. It reports each caught
+render error exactly once through `captureException` — so it picks up the SDK's
+fingerprint and context — and renders a fallback:
+
+```tsx
+// app/layout.tsx
+import { ApmErrorBoundary } from '@nais/apm/react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="nb">
+      <body>
+        <ApmErrorBoundary fallback={<p>Noe gikk galt.</p>}>
+          {children}
+        </ApmErrorBoundary>
+      </body>
+    </html>
+  );
+}
+```
+
+`ApmErrorBoundary` is a client component, but it accepts your Server Component
+`children` as-is — no `'use client'` needed in the layout. The `fallback` can also
+be a render prop `(error, resetError) => node`, and
+`withApmErrorBoundary(Component, props?)` gives you the HOC form.
+
+Next.js also has its own route-segment error boundaries (`error.tsx`,
+`global-error.tsx`). These are separate from `ApmErrorBoundary` — to report errors
+they catch, call `captureException` from them:
+
+```tsx
+// app/global-error.tsx
+'use client';
+
+import { captureException } from '@nais/apm';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="nb">
+      <body>
+        <h2>Noe gikk galt.</h2>
+        <button onClick={reset}>Prøv igjen</button>
+      </body>
+    </html>
+  );
+}
+```
+
+### 3. Track route changes
+
+The App Router does client-side navigation without full page loads, so
+pathname changes need to be reported explicitly. There's no faro-react App Router
+integration; `@nais/apm` ships a small hook, `useApmRouteTracking`, that you feed
+Next's navigation values. Put it in a client component and mount it once in the
+layout:
+
+```tsx
+// app/ApmRouteTracker.tsx
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useApmRouteTracking } from '@nais/apm/react';
+
+export function ApmRouteTracker() {
+  useApmRouteTracking(usePathname(), useSearchParams());
+  return null;
+}
+```
+
+```tsx
+// app/layout.tsx (add to the body)
+import { Suspense } from 'react';
+import { ApmRouteTracker } from './ApmRouteTracker';
+
+// ...inside <body>, alongside {children}:
+<Suspense fallback={null}>
+  <ApmRouteTracker />
+</Suspense>
+```
+
+!!! warning "Wrap the tracker in `<Suspense>`"
+    `useSearchParams()` opts a component into client-side rendering. Wrapping the
+    tracker in a `<Suspense>` boundary keeps that opt-in from bubbling up and
+    forcing the rest of the page to render client-side during static generation.
+
+### 4. Enable tracing (optional)
+
+To connect browser spans to your backend traces in Tempo, turn on tracing in the
+init call. `@grafana/faro-web-tracing` is lazily loaded, so it stays out of your
+bundle unless you enable it:
+
+```ts
+// instrumentation-client.ts
+initNaisAPMClient({
+  namespace: 'my-team',
+  tracing: true,
+});
+```
+
+Trace headers are propagated to your own origin and `*.nav.no` backends by default
+(a non-overridable security floor). Add more origins with
+`tracing: { propagateExtraOrigins: ['https://api.partner.example'] }`. Your backend
+still has to allow the `traceparent` CORS header and export spans to Tempo — see
+[frontend-to-backend trace propagation](trace-propagation.md).
+
+## Pages Router
+
+The Pages Router (`pages/`) — including navikt's golden-path Next.js template —
+works the same way, with two differences: **where you initialize** and **how you
+track routes**.
+
+### Initialize in `_app.tsx`
+
+There's no `instrumentation-client.ts`, so call `initNaisAPMClient` at module
+scope in your custom `App`. It no-ops on the server and is idempotent, so
+top-level is fine:
+
+```tsx
+// pages/_app.tsx
+import type { AppProps } from 'next/app';
+import { initNaisAPMClient, ApmErrorBoundary } from '@nais/apm/react';
+
+initNaisAPMClient({ namespace: 'my-team' });
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <ApmErrorBoundary fallback={<p>Noe gikk galt.</p>}>
+      <Component {...pageProps} />
+    </ApmErrorBoundary>
+  );
+}
+```
+
+### Track routes with the router events
+
+The Pages Router exposes navigation through `next/router` events instead of
+`usePathname()`. Feed the new path into the same hook:
+
+```tsx
+// pages/_app.tsx
+import { useRouter } from 'next/router';
+import { useApmRouteTracking } from '@nais/apm/react';
+
+function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  useApmRouteTracking(router.asPath);
+  // ...render as above
+}
+```
+
+Tracing (`tracing: true`) and the error boundary work identically to the App
+Router.
+
+## Ship readable stack traces
+
+Production stack traces point at minified JavaScript. The Nais telemetry collector
+maps them back to your source **server-side** by fetching your `.map` files from
+the CDN — no upload step, no auth token. You only need to emit sourcemaps and ship
+them alongside your bundle.
+
+For Next.js, enable browser sourcemaps and follow the CDN requirement in
+[Sourcemap deobfuscation](sourcemaps.md):
+
+```js
+// next.config.js
+module.exports = {
+  productionBrowserSourceMaps: true,
+};
+```
+
+!!! warning "Server-rendered assets don't get deobfuscated"
+    Sourcemap resolution only works for bundles served from `cdn.nav.no`. A purely
+    server-rendered Next app that serves its own JS from the pod won't get resolved
+    stack traces unless it also ships static assets to the CDN. See
+    [Sourcemaps → Requirements](sourcemaps.md#requirements).
+
+## Don't send personal data
+
+Nais telemetry lands in a **shared Loki instance every team can read**, so
+identities must never reach it. Two rules:
+
+- `setUser` takes an **opaque, non-identifying** id only — a salted hash, never a
+  raw NAV ident, fødselsnummer, or email. Values that look like PII are dropped in
+  code, and the `email` field is dropped unconditionally.
+
+  ```ts
+  import { setUser } from '@nais/apm';
+  setUser({ id: hash(fnr) }); // an ident/email/fnr passed here is silently dropped
+  ```
+
+- A mandatory PII scrubber runs over every outgoing signal (fnr → `[fnr]`,
+  email → `[email]`, token URL params → `[redacted]`). It's a safety net, not a
+  GDPR guarantee — don't put personal data in error messages in the first place.
+
+## See your errors as issues
+
+Deploy, then trigger an error. Open your service in
+[Nais APM](<<tenant_url("grafana", "a/nais-apm-app/services")>>) and go to the
+**Issues** tab. Your exception shows up as an issue, grouped with other
+occurrences, with its (deobfuscated) stack trace and impact. Filter the source to
+**Browser** to isolate frontend issues.
+
+From there you can [triage it](../../apm/how-to/triage-an-issue.md) or
+[create an alert](../../apm/how-to/create-alerts.md).
+
+## Related
+
+- [Track frontend errors with `@nais/apm`](../../apm/tutorials/track-frontend-errors.md) — the framework-agnostic tutorial and registry setup.
+- [React + Vite quickstart](quickstart-react-vite.md) — for React SPAs.
+- [Migrate from Sentry to `@nais/apm`](migrate-from-sentry.md) — call-site-by-call-site.
+- [`@nais/apm` API reference](../../apm/reference/apm-client-api.md) — every export and option.
+- [Sourcemap deobfuscation](sourcemaps.md) · [Trace propagation](trace-propagation.md)

--- a/docs/observability/frontend/how-to/quickstart-react-vite.md
+++ b/docs/observability/frontend/how-to/quickstart-react-vite.md
@@ -1,0 +1,235 @@
+---
+title: React + Vite quickstart with @nais/apm
+description: >-
+  Instrument a React single-page app built with Vite using @nais/apm — init at
+  the entry point, an error boundary, and React Router route tracking.
+tags: [how-to, observability, frontend, apm, react, vite]
+conditional: [tenant, nav]
+---
+
+# React + Vite quickstart with `@nais/apm`
+
+Instrument a React single-page app (SPA) built with [Vite](https://vitejs.dev)
+using [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md), the Nais browser
+telemetry SDK, and see your errors as issues in
+[Nais APM](../../apm/README.md). This is the fast path for a client-rendered
+React app: init at the entry point, a React error boundary, and route tracking for
+React Router.
+
+!!! note "Status: pre-release"
+    `@nais/apm` is pre-1.0. Pin an exact version and read the
+    [CHANGELOG](https://github.com/nais/apm/blob/main/CHANGELOG.md) before
+    upgrading. This guide targets `0.2.0`.
+
+!!! tip "Migrating off Sentry?"
+    If your app calls `Sentry.init` today, follow
+    [Migrate from Sentry to `@nais/apm`](migrate-from-sentry.md) instead — it maps
+    every `@sentry/react` call site to its `@nais/apm` equivalent and lists what's
+    different. On Next.js instead? See the
+    [Next.js quickstart](quickstart-nextjs.md).
+
+## Prerequisites
+
+- A React SPA built with Vite, deployed on Nais.
+- The `@nais` package registry configured in your `.npmrc`. This is a one-time
+  setup — follow
+  [step 1 of Track frontend errors](../../apm/tutorials/track-frontend-errors.md#1-configure-the-package-registry).
+
+## Install
+
+```sh
+pnpm add @nais/apm@0.2.0
+# or: npm install @nais/apm@0.2.0 / yarn add @nais/apm@0.2.0
+```
+
+The React helpers used below — `ApmErrorBoundary`, `enableApmReactRouterV6`,
+`ApmRoutes` — live in the `@nais/apm/react` entry point.
+
+## 1. Initialize at the entry point
+
+Call `init()` once, as early as possible, in your app's entry module — before you
+render. On Nais, everything resolves automatically except the team, which you pass
+as `namespace`:
+
+```tsx
+// src/main.tsx
+import { init } from '@nais/apm';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+init({
+  namespace: 'my-team', // your Nais team — see the note below
+});
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+```
+
+`init()` is idempotent, so React Strict Mode's double render won't re-initialize.
+App name, version, environment, and the collector URL
+[resolve automatically](../../apm/reference/apm-client-api.md#configuration-resolution)
+from Nais meta tags or `NAIS_*` build env. On `localhost`, where no collector
+resolves, it sends **nothing** and echoes every signal to the console.
+
+!!! info "`namespace` is your team"
+    `namespace` is the Nais team that owns the app (its Kubernetes namespace).
+    Nais APM attributes all telemetry by team, so it's effectively required. Pass
+    it explicitly as shown, or let it resolve from a
+    `<meta name="nais-team" content="my-team">` tag or the `NAIS_TEAM` env — then
+    you can drop the option entirely.
+
+!!! tip "Inlining `NAIS_*` env with Vite"
+    The env-var resolution path only works if Vite inlines the values at build
+    time. Expose them through Vite's
+    [`define`](https://vitejs.dev/config/shared-options.html#define), e.g.
+    `define: { 'process.env.NAIS_TEAM': JSON.stringify(process.env.NAIS_TEAM) }`.
+    Passing `namespace` explicitly (or via a meta tag) avoids needing this.
+
+## 2. Add an error boundary
+
+Wrap your app in `ApmErrorBoundary`. It reports each caught render error exactly
+once through `captureException` — picking up the SDK's fingerprint and context —
+and renders a fallback:
+
+```tsx
+// src/App.tsx
+import { ApmErrorBoundary } from '@nais/apm/react';
+
+export default function App() {
+  return (
+    <ApmErrorBoundary fallback={<p>Noe gikk galt.</p>}>
+      <Routes /> {/* your app */}
+    </ApmErrorBoundary>
+  );
+}
+```
+
+The `fallback` can also be a render prop `(error, resetError) => node`, and
+`withApmErrorBoundary(Component, props?)` gives you the HOC form.
+
+## 3. Track route changes (React Router)
+
+For client-side navigation, report route changes so pageviews and errors carry the
+right URL. `@nais/apm` re-exports faro-react's route tracking as `ApmRoutes`. Call
+`enableApmReactRouterV6` once after `init()`, passing your own `react-router-dom`
+exports (the SDK never imports react-router itself, which keeps its version out of
+its dependency tree), then render `<ApmRoutes>` where you'd render `<Routes>`:
+
+```tsx
+// src/main.tsx — after init()
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+import { enableApmReactRouterV6 } from '@nais/apm/react';
+
+enableApmReactRouterV6({
+  createRoutesFromChildren,
+  matchRoutes,
+  Routes,
+  useLocation,
+  useNavigationType,
+});
+```
+
+```tsx
+// wherever you render your routes
+import { Route } from 'react-router-dom';
+import { ApmRoutes } from '@nais/apm/react';
+
+<ApmRoutes>
+  <Route path="/" element={<Home />} />
+  <Route path="/orders/:id" element={<Order />} />
+</ApmRoutes>
+```
+
+!!! warning "React Router v6 only"
+    Route tracking currently wires up **React Router v6**. Many navikt apps are on
+    **v7** — the wiring shown here targets v6's API, so on v7 confirm these exports
+    still resolve, or track it against the
+    [`@nais/apm` CHANGELOG](https://github.com/nais/apm/blob/main/CHANGELOG.md). v5
+    and the data-router variants are not wired yet. The error boundary and manual
+    captures work regardless of router version.
+
+## 4. Enable tracing (optional)
+
+To connect browser spans to your backend traces in Tempo, turn on tracing.
+`@grafana/faro-web-tracing` is lazily loaded, so it stays out of your bundle unless
+you enable it:
+
+```ts
+init({
+  namespace: 'my-team',
+  tracing: true,
+});
+```
+
+Trace headers are propagated to your own origin and `*.nav.no` backends by default
+(a non-overridable security floor). Add more origins with
+`tracing: { propagateExtraOrigins: ['https://api.partner.example'] }`. Your backend
+still has to allow the `traceparent` CORS header and export spans to Tempo — see
+[frontend-to-backend trace propagation](trace-propagation.md).
+
+## Ship readable stack traces
+
+Production stack traces point at minified JavaScript. The Nais telemetry collector
+maps them back to your source **server-side** by fetching your `.map` files from
+the CDN — no upload step, no auth token. You only need to emit sourcemaps and ship
+them alongside your bundle. For Vite:
+
+```js
+// vite.config.js
+export default {
+  build: {
+    sourcemap: true, // emits .map files
+  },
+};
+```
+
+A Vite SPA served from `cdn.nav.no` is the ideal case for deobfuscation — the
+`.map` files sit right next to the bundle. Follow
+[Sourcemap deobfuscation](sourcemaps.md) for the CDN requirement.
+
+## Don't send personal data
+
+Nais telemetry lands in a **shared Loki instance every team can read**, so
+identities must never reach it. Two rules:
+
+- `setUser` takes an **opaque, non-identifying** id only — a salted hash, never a
+  raw NAV ident, fødselsnummer, or email. Values that look like PII are dropped in
+  code, and the `email` field is dropped unconditionally.
+
+  ```ts
+  import { setUser } from '@nais/apm';
+  setUser({ id: hash(fnr) }); // an ident/email/fnr passed here is silently dropped
+  ```
+
+- A mandatory PII scrubber runs over every outgoing signal (fnr → `[fnr]`,
+  email → `[email]`, token URL params → `[redacted]`). It's a safety net, not a
+  GDPR guarantee — don't put personal data in error messages in the first place.
+
+## See your errors as issues
+
+Deploy, then trigger an error. Open your service in
+[Nais APM](<<tenant_url("grafana", "a/nais-apm-app/services")>>) and go to the
+**Issues** tab. Your exception shows up as an issue, grouped with other
+occurrences, with its (deobfuscated) stack trace and impact. Filter the source to
+**Browser** to isolate frontend issues.
+
+From there you can [triage it](../../apm/how-to/triage-an-issue.md) or
+[create an alert](../../apm/how-to/create-alerts.md).
+
+## Related
+
+- [Track frontend errors with `@nais/apm`](../../apm/tutorials/track-frontend-errors.md) — the framework-agnostic tutorial and registry setup.
+- [Next.js quickstart](quickstart-nextjs.md) — for Next.js apps.
+- [Migrate from Sentry to `@nais/apm`](migrate-from-sentry.md) — call-site-by-call-site.
+- [`@nais/apm` API reference](../../apm/reference/apm-client-api.md) — every export and option.
+- [Sourcemap deobfuscation](sourcemaps.md) · [Trace propagation](trace-propagation.md)

--- a/docs/observability/frontend/how-to/setup-nextjs.md
+++ b/docs/observability/frontend/how-to/setup-nextjs.md
@@ -11,11 +11,12 @@ Faro is a browser-only SDK and cannot run in React Server Components. You need a
 
 {% if tenant() == "nav" %}
 !!! tip "Prefer `@nais/apm` for most apps"
-    Most apps should reach for the [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md)
-    SDK instead of wiring up raw Faro: `init()` is zero-config, PII scrubbing is
-    built in, and you still call it from a `'use client'` entry point. This guide
-    is the lower-level path — use it when you need trace propagation, which the
-    `@nais/apm` `0.1.0` SDK doesn't wrap yet.
+    Most apps should reach for the `@nais/apm` SDK instead of wiring up raw Faro:
+    `init()` is zero-config, PII scrubbing is built in, and it wraps error
+    boundaries, route tracking, and tracing. Start with the
+    [Next.js quickstart with `@nais/apm`](quickstart-nextjs.md). This guide is the
+    lower-level path — reach for it when you need something the SDK doesn't wrap
+    yet.
 {% endif %}
 
 ## Prerequisites


### PR DESCRIPTION
Authors `@nais/apm` **frontend framework quickstart guides**, ordered by real navikt usage (nais/grafana-apm-app#112).

## What's here

- **[Next.js quickstart](docs/observability/frontend/how-to/quickstart-nextjs.md)** — the largest NAV frontend framework (56 Next repos). **App Router** is the primary path (`initNaisAPMClient` in `instrumentation-client.ts`, `ApmErrorBoundary` in the root layout + `global-error.tsx`, `useApmRouteTracking` with a `<Suspense>` note, opt-in tracing). **Pages Router** is a variant section within the same page (`_app.tsx` init + `next/router` events), covering navikt's golden-path template.
- **[React + Vite quickstart](docs/observability/frontend/how-to/quickstart-react-vite.md)** — the #2 frontend (48 repos; Vite, not CRA). Entry-point `init({ namespace })`, `ApmErrorBoundary`, `enableApmReactRouterV6(...)` + `<ApmRoutes>` for React Router v6 (with a v7 caveat), opt-in tracing.

Both pages are **nav-gated** (`conditional: [tenant, nav]`), copy-pasteable, and cover the server-side sourcemap-resolution note and the PII/opaque-id (`setUser`) rule. They link into the [Sentry migration guide](https://github.com/nais/doc/pull/877), the sourcemap guide, trace propagation, and the APM Issues tab.

## App Router vs Pages Router

Kept as **one Next.js page** with the App Router as the main flow and a Pages Router section for the two differences (where you init, how you track routes) — rather than two parallel pages. The existing raw-Faro `setup-nextjs.md` stays as the tenant-agnostic lower-level guide (ssb keeps it); its "prefer @nais/apm" tip now points at the new quickstart.

## Section wiring

Updated the frontend section landing (`README.md`) — the nav "Get started" list and a new nav-gated framework-quickstart table in "Guides".

## Dependency on #877

This branch is **stacked on #877** (the Sentry migration guide) so the inbound links resolve and the build is green. Merge #877 first; the shared commit then drops out of this diff automatically.

## Verification

`mise run build nav ssb` is green. Both quickstarts render for **nav** and are absent for **ssb**; the raw-Faro guides remain for ssb. No leftover `{% %}` / `<< >>` tokens (`<<tenant_url>>` resolves to `https://grafana.nav.cloud.nais.io/a/nais-apm-app/services`). Internal links to sourcemaps, trace propagation, the migration guide, and the APM tabs resolve.