### PR TITLE
docs(observability): fix frontend + apm review findings

### DIFF
--- a/docs/observability/apm/how-to/create-alerts.md
+++ b/docs/observability/apm/how-to/create-alerts.md
@@ -2,7 +2,8 @@
 title: Create alerts from templates
 description: >-
   Turn a Nais APM issue or service into a Grafana alert rule using the built-in
-  error-rate, exception-spike, web-vitals, and new-exception templates.
+  error-rate, SLO burn-rate, exception-spike, web-vitals, and new-exception
+  templates.
 tags: [how-to, observability, apm, alerting]
 ---
 
@@ -35,21 +36,22 @@ Nais APM, so a notification takes you to the exact error.
 | Template | Alerts when | Scope |
 | -------- | ----------- | ----- |
 | **Error rate** | The service's error ratio crosses ~5% of requests | Service |
+| **SLO burn rate** | The error budget for a target SLO burns too fast — fast burn (14.4× over 1h) pages, slow burn (6× over 6h) tickets | Service |
 | **Exception spike** | Occurrences of a specific issue exceed a threshold in a 5-minute window | A single issue |
 | **New exceptions** | A new exception pattern appears that wasn't there before | Service |
 | **Web vitals** | Core Web Vitals degrade (frontend UX health) | Service (frontend) |
 
 - **Error rate** builds a Mimir rule from the service's RED metrics.
+- **SLO burn rate** builds a Google-SRE multi-window multi-burn-rate rule on the
+  service's RED error ratio. Pick **fast burn** (a paging signal — the budget
+  burns 14.4× over 1h) or **slow burn** (a non-paging ticket — 6× over 6h) from
+  the service page; both are derived from a target SLO you set.
 - **Exception spike** is per-issue — open it from an issue drawer to alert on
   that fingerprint specifically.
 - **New exceptions** is a LogQL approximation of "an error we've never seen
   before just showed up." It ships with an honest in-product explainer of what
   it can and can't catch.
 - **Web vitals** watches the browser-side performance signals, not errors.
-
-!!! note "No burn-rate template yet"
-    SLO / error-budget burn-rate alerting is on the roadmap but not shipped.
-    Only the four templates above exist today.
 
 ## Where the deep links point
 

--- a/docs/observability/apm/reference/apm-client-api.md
+++ b/docs/observability/apm/reference/apm-client-api.md
@@ -37,12 +37,14 @@ init(options?: InitOptions): Faro
 
 ### InitOptions
 
-All fields are optional. `app`, `version`, `environment`, and `telemetryUrl`
+All fields are optional to pass, though `namespace` is effectively required (see
+its row below). `app`, `namespace`, `version`, `environment`, and `telemetryUrl`
 each resolve independently (see [Configuration resolution](#configuration-resolution)).
 
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `app` | `string` | Application name. |
+| `namespace` | `string` | The nais team (Kubernetes namespace) that owns the app. **Effectively required** — the plugin attributes all telemetry by team, so without it telemetry resolves to `unknown-team` and can't be tied to your app. Resolves from `<meta name="nais-team">` / `nais-namespace` or `NAIS_TEAM` / `NAIS_NAMESPACE` when omitted. |
 | `version` | `string` | App version / release. Used for grouping and release tagging; also set as Faro `release`. |
 | `environment` | `string` | Environment, e.g. `prod-gcp`. |
 | `telemetryUrl` | `string` | Collector URL. |
@@ -60,6 +62,7 @@ tighten-only). See [Enable session replay](../how-to/enable-session-replay.md).
 ```ts
 init({
   app: 'my-app',
+  namespace: 'my-team', // the nais team that owns this app — effectively required
   version: '2026.07.04-abc1234',
   environment: 'prod-gcp',
   telemetryUrl: undefined, // usually omitted — resolved automatically on nais
@@ -76,21 +79,23 @@ init({
 
 ### Configuration resolution
 
-Each of `app`, `version`, `environment`, and `telemetryUrl` resolves
-independently, highest priority first:
+Each of `app`, `namespace`, `version`, `environment`, and `telemetryUrl`
+resolves independently, highest priority first:
 
 1. **Explicit `init()` options.**
 2. **Nais meta tags** in the served HTML:
    ```html
    <meta name="nais-app" content="my-app">
+   <meta name="nais-team" content="my-team"> <!-- or nais-namespace -->
    <meta name="nais-cluster" content="prod-gcp">
    <meta name="nais-version" content="2026.07.03-abc1234">
    <meta name="nais-telemetry-url" content="https://telemetry.<tenant>.example/collect"> <!-- injected by the platform, not written by hand -->
    ```
-3. **Build-time environment variables** — `NAIS_APP_NAME`, `NAIS_CLUSTER_NAME`,
-   and a version derived from `NAIS_APP_IMAGE`'s tag (or `GITHUB_SHA`). These
-   only work when your bundler inlines `process.env.*` (webpack `DefinePlugin`,
-   Vite `define`, Next.js `env`).
+3. **Build-time environment variables** — `NAIS_APP_NAME`, `NAIS_TEAM` (or
+   `NAIS_NAMESPACE`), `NAIS_CLUSTER_NAME`, and a version derived from
+   `NAIS_APP_IMAGE`'s tag (or `GITHUB_SHA`). These only work when your bundler
+   inlines `process.env.*` (webpack `DefinePlugin`, Vite `define`, Next.js
+   `env`).
 4. **Collector fallback** — with no explicit or meta collector URL, well-known
    Nais collectors are derived from the cluster name (`prod-*` and `dev-*`).
 5. **Dev mode** — if no collector URL resolves at all (typically localhost),

--- a/docs/observability/frontend/README.md
+++ b/docs/observability/frontend/README.md
@@ -24,9 +24,10 @@ With 95+ applications already using Faro, it's the standard way to monitor front
     and [Issues](../apm/tutorials/get-started.md#3-check-the-issues-tab) tabs.
 
     Start with [Track frontend errors with `@nais/apm`](../apm/tutorials/track-frontend-errors.md).
-    Reach for raw Faro (the guides below) when you need something `@nais/apm`
-    doesn't cover yet — most notably [trace propagation](how-to/trace-propagation.md),
-    which the `0.1.0` SDK doesn't wrap.
+    Reach for raw Faro (the guides below) only when you need the lower-level SDK
+    directly — everything the platform recommends, including
+    [trace propagation](how-to/trace-propagation.md)
+    (`init({ tracing: true })`), is available through `@nais/apm`.
 {% endif %}
 
 ## What you get
@@ -45,7 +46,7 @@ With 95+ applications already using Faro, it's the standard way to monitor front
 2. **Next.js (App Router or Pages Router):** [:simple-nextdotjs: Next.js quickstart with `@nais/apm`](how-to/quickstart-nextjs.md)
 3. **React SPA + Vite:** [:simple-react: React + Vite quickstart with `@nais/apm`](how-to/quickstart-react-vite.md)
 4. **Coming from Sentry?** [Migrate from Sentry to `@nais/apm`](how-to/migrate-from-sentry.md)
-5. **Need raw Faro** (e.g. trace propagation on `0.1.0`)**?** [Set up Faro](how-to/setup-faro.md) · [Next.js with raw Faro](how-to/setup-nextjs.md)
+5. **Need the lower-level SDK directly?** [Set up Faro](how-to/setup-faro.md) · [Next.js with raw Faro](how-to/setup-nextjs.md)
 6. **Want end-to-end traces?** [Connect frontend to backend](how-to/trace-propagation.md)
 7. **Stack traces look minified?** [Sourcemaps](how-to/sourcemaps.md) · [Troubleshooting](reference/troubleshooting.md)
 {% else %}
@@ -130,8 +131,10 @@ framework:
 | [React + Vite with `@nais/apm`](how-to/quickstart-react-vite.md) | React SPA: entry-point init, error boundary, React Router tracking |
 | [Migrate from Sentry](how-to/migrate-from-sentry.md) | Move an existing `@sentry/*` app onto `@nais/apm` |
 
-The raw-Faro guides below are the lower-level path — reach for them when you need
-something `@nais/apm` doesn't wrap yet (most notably [trace propagation](how-to/trace-propagation.md)).
+The raw-Faro guides below are the lower-level path — reach for them only when you
+need to work with the Faro SDK directly. Everything the platform recommends,
+including [trace propagation](how-to/trace-propagation.md), is available through
+`@nais/apm` (`init({ tracing: true })`).
 {% endif %}
 
 | Guide | Description |

--- a/docs/observability/frontend/how-to/custom-metrics.md
+++ b/docs/observability/frontend/how-to/custom-metrics.md
@@ -140,15 +140,19 @@ function ExpensiveComponent() {
 
   useEffect(() => {
     const renderTime = performance.now() - startRef.current;
-    faro.api.pushMeasurement({
-      type: 'component-render',
-      values: {
-        render_ms: Math.round(renderTime),
+    faro.api.pushMeasurement(
+      {
+        type: 'component-render',
+        values: {
+          render_ms: Math.round(renderTime),
+        },
       },
-      context: {
-        component: 'ExpensiveComponent',
+      {
+        context: {
+          component: 'ExpensiveComponent',
+        },
       },
-    });
+    );
   }, []);
 
   return <div>...</div>;

--- a/docs/observability/frontend/how-to/setup-faro.md
+++ b/docs/observability/frontend/how-to/setup-faro.md
@@ -14,9 +14,9 @@ Add [Grafana Faro](https://www.npmjs.com/package/@grafana/faro-web-sdk) to a fro
     SDK — a thin Faro wrapper that gives you zero-config `init()`, **built-in PII
     scrubbing** (fødselsnummer, emails, and token URL parameters), and a fixed
     console instrumentation, so you don't hand-roll the `beforeSend` filtering
-    and `app` metadata shown below. Use raw Faro when you need something
-    `@nais/apm` `0.1.0` doesn't wrap yet — most notably
-    [trace propagation](trace-propagation.md).
+    and `app` metadata shown below. It also wraps
+    [trace propagation](trace-propagation.md) (`init({ tracing: true })`). Use
+    raw Faro only when you need to work with the lower-level SDK directly.
 {% endif %}
 
 ## Prerequisites

--- a/docs/observability/frontend/how-to/setup-nextjs.md
+++ b/docs/observability/frontend/how-to/setup-nextjs.md
@@ -13,10 +13,10 @@ Faro is a browser-only SDK and cannot run in React Server Components. You need a
 !!! tip "Prefer `@nais/apm` for most apps"
     Most apps should reach for the `@nais/apm` SDK instead of wiring up raw Faro:
     `init()` is zero-config, PII scrubbing is built in, and it wraps error
-    boundaries, route tracking, and tracing. Start with the
-    [Next.js quickstart with `@nais/apm`](quickstart-nextjs.md). This guide is the
-    lower-level path — reach for it when you need something the SDK doesn't wrap
-    yet.
+    boundaries, route tracking, and tracing (`init({ tracing: true })`). Start
+    with the [Next.js quickstart with `@nais/apm`](quickstart-nextjs.md). This
+    guide is the lower-level path — reach for it only when you need to work with
+    the Faro SDK directly.
 {% endif %}
 
 ## Prerequisites
@@ -51,7 +51,7 @@ import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 export default function Faro({ collectorUrl }: { collectorUrl?: string }) {
   useEffect(() => {
-    if (faro.config) return; // already initialized
+    if (faro.api) return; // already initialized
 
     try {
       initializeFaro({
@@ -85,7 +85,7 @@ import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 export default function Faro({ collectorUrl }: { collectorUrl?: string }) {
   useEffect(() => {
-    if (faro.config) return; // already initialized
+    if (faro.api) return; // already initialized
 
     try {
       initializeFaro({

--- a/docs/observability/frontend/how-to/trace-propagation.md
+++ b/docs/observability/frontend/how-to/trace-propagation.md
@@ -48,7 +48,7 @@ import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
 initializeFaro({
   url: '...', // collector endpoint
-  app: { name: 'my-app' },
+  app: { name: 'my-app', namespace: 'my-team' },
   instrumentations: [
     ...getWebInstrumentations(),
     new TracingInstrumentation({


### PR DESCRIPTION
Fixes verified review findings in the frontend and APM observability docs. Code claims were grounded against the `@nais/apm` SDK source (`apm-client/src`) and the plugin (`pkg/plugin/alerttemplates.go`, `src/pages/tabs/AlertsTab.tsx`).

## Frontend (`docs/observability/frontend/`)
1. **README.md, setup-faro.md, setup-nextjs.md** — removed the stale framing that raw Faro is needed for trace propagation. Tracing shipped in `@nais/apm` via `init({ tracing: true })` (lazy `@grafana/faro-web-tracing`, same-origin + `*.nav.no` propagation floor). Raw Faro is now framed only as the lower-level path.
2. Same files — dropped the stale `0.1.0` version markers (docs track `0.4.0`).
3. **custom-metrics.md** — the render-time example put `context` inside the measurement payload (no `context` field there → silently dropped). Moved it to the second argument (`PushMeasurementOptions`), matching the correct earlier example.
4. **trace-propagation.md** — added the required `namespace` to the Faro `app` init example.
5. **setup-nextjs.md** — standardized the init guard on `if (faro.api) return;` (matches `reference/troubleshooting.md`).

## APM (`docs/observability/apm/`)
6. **reference/apm-client-api.md** — documented `namespace` (team), effectively required (without it telemetry resolves to `unknown-team`): added it to the InitOptions table, the meta-tag block (`nais-team`/`nais-namespace`), the env-var list (`NAIS_TEAM`/`NAIS_NAMESPACE`), the resolution sentences, and the init example. Left the *limitations* / *version-marker* sections untouched to minimize conflict with the unmerged DRY PR #877.
7. **how-to/create-alerts.md** — `slo-burn-rate` is a shipped template (fast/slow buttons in `AlertsTab.tsx`, `sloBurnRateDefaults` in `alerttemplates.go`). Corrected the false "not shipped / only four templates" note and added the 5th row to the templates table.

## Verification
- `mise run build nav ssb` — green.
- Links on the changed pages resolve to existing pages.
- Corrected code examples validated against the SDK signatures.