### PR TITLE
docs(logging): fix verified review findings in logging observability docs

### DIFF
--- a/docs/observability/logging/README.md
+++ b/docs/observability/logging/README.md
@@ -1,6 +1,5 @@
 ---
-description: >-
-  Logs are a way to understand what is happening in your application. They are usually text-based and are often used for debugging. Since the format of logs is usually not standardized, it can be difficult to query and aggregate logs and thus we recommend using metrics for dashboards and alerting.
+description: Understand how application logging works in Nais, its purpose, good practices, and the available log destinations.
 tags: [explanation, logging, observability, services]
 ---
 

--- a/docs/observability/logging/how-to/logs-in-dashboards.md
+++ b/docs/observability/logging/how-to/logs-in-dashboards.md
@@ -1,10 +1,14 @@
+---
+description: Add logs to your Grafana dashboards and correlate them with metrics and traces.
+tags: [how-to, logging, observability, loki]
+---
 # Adding logs to your Grafana dashboard
 
 In this guide, you will learn how to add logs to your Grafana dashboards. Logs are a valuable source of information for debugging and monitoring your applications. By adding logs to your Grafana dashboards, you can correlate logs with metrics and traces to get a complete picture of your application's health.
 
 ## Prerequisites
 
-- [Enabled Loki logging for your application](./loki.md#enable-logging-to-grafana-loki)
+- [Enabled Loki logging for your application](./loki.md#default-logging-with-grafana-loki)
 - A Grafana dashboard
 
 ## Add logs to your dashboard

--- a/docs/observability/logging/how-to/logs-metrics-alerts.md
+++ b/docs/observability/logging/how-to/logs-metrics-alerts.md
@@ -1,3 +1,7 @@
+---
+description: Use Loki-derived metrics to monitor log patterns and create Prometheus alerts.
+tags: [how-to, logging, observability, loki, alerts]
+---
 # Metrics and alerts for logs
 
 This guide shows how to use Loki metrics for monitoring log patterns and creating alerts.
@@ -34,7 +38,7 @@ sum(loki:service:loglevel:count1m{service_name="my-app", detected_level="error"}
 Show trends over time:
 
 ```promql
-sum(loki:service:loglevel:count1m{service_name="my-app", detected_level="error"}[60m:1m]) by (service_name)
+sum by (service_name) (sum_over_time(loki:service:loglevel:count1m{service_name="my-app", detected_level="error"}[60m:1m]))
 ```
 
 Compare error rates across clusters:

--- a/docs/observability/logging/reference/destinations.md
+++ b/docs/observability/logging/reference/destinations.md
@@ -29,9 +29,9 @@ spec:
 The following log destinations are available in Nais:
 
 {% if tenant() != "ssb" %}
-- [`loki`](../how-to/loki.md#enable-logging-to-loki)
+- [`loki`](../how-to/loki.md#default-logging-with-grafana-loki)
 {% endif %}
-- [`team_logs`](../how-to/team-logs.md#enable-team-logs)
+- [`team_logs`](../how-to/team-logs.md#how-to-configure-team-logs)
 {% if tenant() == "nav" %}
 - [`elastic`](../how-to/nav-logs-dashboards.md#enable-logging-to-nav-logs)
 {% endif %}

--- a/docs/observability/logging/reference/dql.md
+++ b/docs/observability/logging/reference/dql.md
@@ -7,6 +7,10 @@ conditional: [tenant, nav]
 
 # Dashboards Query Language (DQL) Reference
 
+!!! warning "Not supported by Nais"
+
+    This logging solution is not supported by Nais. See [Loki](../how-to/loki.md) for the new default logging solution.
+
 The Dashboards Query Language (DQL) is a simple text-based query language for filtering data in nav-logs (OpenSearch Dashboards). DQL is the default query language in OpenSearch Dashboards and is simpler to use than Lucene query syntax.
 
 ![Screenshot: DQL query in nav-logs](../../../assets/nav-logs-dql.png)

--- a/docs/observability/logging/reference/logql.md
+++ b/docs/observability/logging/reference/logql.md
@@ -34,14 +34,20 @@ This will return all logs where the label `label` has the value `value`. LogQL r
 
 #### Selector Operators
 
-Similar to PromQL, LogQL supports a set of operators for comparing labels and values:
+The stream selector only supports matching on label values. The following operators are available:
 
-- `=~` - Regular expression match
-- `!~` - Regular expression mismatch
 - `=` - Label value match
 - `!=` - Label value mismatch
-- `>` - Greater than (numeric)
-- `<` - Less than (numeric)
+- `=~` - Regular expression match
+- `!~` - Regular expression mismatch
+
+Numeric comparison is **not** available in the stream selector. To compare numeric values, first extract them with a parser and then use a label-filter expression later in the pipeline:
+
+```logql
+{service_name="my-app"} | json | status >= 400
+```
+
+Label-filter expressions support the comparison operators `==`, `!=`, `>`, `>=`, `<`, and `<=` on values extracted by a parser.
 
 ### Log Pipeline
 

--- a/docs/observability/logging/reference/loki-labels.md
+++ b/docs/observability/logging/reference/loki-labels.md
@@ -5,18 +5,37 @@ tags: [reference, loki, logging]
 
 # Loki Labels Reference
 
-In Grafana Loki, logs are stored as key-value pairs called labels. Labels are used to filter, aggregate, and search for logs and can be used in LogQL queries to search for logs by message, by field, or by a combination of both.
+In Grafana Loki, each log stream is identified by a small set of **indexed labels**. Additional context is attached to individual log lines as **structured metadata**. Both can be used to filter logs in LogQL queries, but only indexed labels belong inside the stream selector `{…}`.
 
-The following labels are available in Grafana Loki by default:
+## Indexed labels
+
+Indexed labels form the stream selector and are the only labels you should place inside the curly braces `{…}` of a LogQL query. In Nais, only the following labels are indexed:
+
+| Label               | Description                                                    | Applicable to |
+| ------------------- | ------------------------------------------------------------- | ------------- |
+| `service_name`      | The name of the application that generated the log line.      | All           |
+| `service_namespace` | The namespace of the application that generated the log line. | All           |
+| `k8s_cluster_name`  | The name of the Kubernetes cluster that generated the log line. | Kubernetes  |
+
+Example stream selector using indexed labels only:
+
+```logql
+{service_name="my-app", service_namespace="my-team", k8s_cluster_name="prod-gcp"}
+```
+
+## Structured metadata
+
+Everything else is attached to each log line as structured metadata rather than being indexed. Structured metadata is fully filterable, but it **must not** be placed inside the stream selector `{…}`. Instead, filter on it later in the pipeline with a label-filter expression:
+
+```logql
+{service_name="my-app"} | detected_level="error"
+```
 
 | Field                | Description                                                               | Applicable to |
 | -------------------- | ------------------------------------------------------------------------- | ------------- |
 | `detected_level`     | The log level detected by the log parser.                                 | All           |
-| `service_name`       | The name of the application that generated the log line.                  | All           |
-| `service_namespace`  | The namespace of the application that generated the log line.             | All           |
 | `k8s_container_name` | The name of the Kubernetes container that generated the log line.         | Kubernetes    |
 | `k8s_pod_name`       | The name of the Kubernetes pod that generated the log line.               | Kubernetes    |
 | `k8s_node_name`      | The name of the Kubernetes node that generated the log line.              | Kubernetes    |
-| `k8s_cluster_name`   | The name of the Kubernetes cluster that generated the log line.           | Kubernetes    |
 | `collector_name`     | The name of the log collector that ingested the log line.                 | All           |
-| `kind`               | The kind of log line. Can be `exception`, `event` `log` or `measurement`, | Faro SDK      |
+| `kind`               | The kind of log line. Can be `exception`, `event`, `log` or `measurement`. | Faro SDK      |

--- a/docs/observability/logging/reference/loki-metrics.md
+++ b/docs/observability/logging/reference/loki-metrics.md
@@ -3,6 +3,8 @@ title: Loki Metrics Reference
 description: Reference documentation for metrics derived from Loki logs
 ---
 
+# Loki Metrics Reference
+
 This reference document describes the metrics that are automatically derived from logs collected by Loki in the NAIS platform.
 
 ## `loki:service:loglevel:count1m`
@@ -34,14 +36,14 @@ The `loki:service:loglevel:count1m` metric provides a pre-aggregated count of lo
 Count of error logs for a specific service in the last hour:
 
 ```promql
-sum(loki:service:loglevel:count1m{service_name="my-app", service_namespace="my-team", detected_level="error"}[60m:1m])
+sum_over_time(loki:service:loglevel:count1m{service_name="my-app", service_namespace="my-team", detected_level="error"}[60m:1m])
 ```
 
 Ratio of errors to total logs for all services in a namespace:
 
 ```promql
-sum(loki:service:loglevel:count1m{service_namespace="team-a", service_namespace="my-team", detected_level="error"}) /
-sum(loki:service:loglevel:count1m{service_namespace="team-a", service_namespace="my-team"})
+sum(loki:service:loglevel:count1m{service_namespace="my-team", detected_level="error"}) /
+sum(loki:service:loglevel:count1m{service_namespace="my-team"})
 ```
 
 #### Alert Examples
@@ -55,7 +57,7 @@ sum(loki:service:loglevel:count1m{detected_level="error"}) > 100
 ### Best Practices
 
 - Do not use `increase()` or `rate()` functions with this metric, as it is already pre-aggregated for 1-minute intervals
-- For longer time ranges, use range vector selectors like `[60m:1m]` to sample at 1-minute intervals
+- For longer time ranges, wrap the metric in `sum_over_time(...[60m:1m])` to add up the pre-aggregated counts over the window; a bare subquery like `[60m:1m]` returns a range vector and cannot be passed directly to `sum()`
 - Consider setting appropriate thresholds for alerts based on your application's normal logging behavior
 - Combine with other metrics (like HTTP status codes) for more comprehensive service health monitoring
 

--- a/docs/observability/tracing/how-to/correlate-traces-logs.md
+++ b/docs/observability/tracing/how-to/correlate-traces-logs.md
@@ -9,7 +9,7 @@ This guide explains how to correlate traces with logs in Grafana Tempo. When set
 ## Prerequisites
 
 1. [Auto-instrumentation enabled](../../how-to/auto-instrumentation.md) (or manual OTel SDK setup)
-2. [Logs sent to Grafana Loki](../../logging/how-to/loki.md#enable-logging-to-grafana-loki)
+2. [Logs sent to Grafana Loki](../../logging/how-to/loki.md#default-logging-with-grafana-loki)
 
 ## How it works
 


### PR DESCRIPTION
Fixes verified review findings under `docs/observability/logging/`.

## Changes

1. **`reference/logql.md`** — Removed `>`/`<` from the Selector Operators list (stream selectors `{…}` only support `=`, `!=`, `=~`, `!~`). Documented numeric comparison as a label-filter expression after a parser (`| json | status >= 400`).
2. **`reference/loki-metrics.md`** & **`how-to/logs-metrics-alerts.md`** — Replaced invalid `sum(metric[60m:1m])` (a subquery yields a range vector) with `sum_over_time(metric[60m:1m])`, and fixed the loki-metrics "Best Practices" guidance. The grouped example became `sum by (service_name) (sum_over_time(...))` since `sum_over_time` takes no `by` clause.
3. **`reference/loki-metrics.md`** — Removed the conflicting duplicate `service_namespace` matcher that produced zero series.
4. **`reference/loki-labels.md`** — Split the table into **Indexed labels** (`k8s_cluster_name`, `service_name`, `service_namespace` — the only indexed stream labels, live-verified against Loki) vs **Structured metadata** (everything else), and corrected guidance: structured metadata is filterable via a label filter (`| detected_level="error"`) but must not go inside the stream selector `{…}`.
5. **Dead anchors** — Repointed `loki.md#enable-logging-to-*` links to `#default-logging-with-grafana-loki` in `reference/destinations.md`, `how-to/logs-in-dashboards.md`, and `tracing/how-to/correlate-traces-logs.md` (same renamed heading); repointed the `team-logs.md` link to `#how-to-configure-team-logs`.
6. **Minors** — Added YAML frontmatter to `how-to/logs-in-dashboards.md` and `how-to/logs-metrics-alerts.md`; gave `reference/loki-metrics.md` an H1; de-duped the README description repeated in its body; added the "not supported by Nais" banner to `reference/dql.md`.

## Verification

`mise run build nav ssb` is green with no broken cross-links on the changed pages.