### PR TITLE
docs(observability): fix verified metrics & tracing review findings

### DIFF
--- a/docs/observability/metrics/README.md
+++ b/docs/observability/metrics/README.md
@@ -15,8 +15,9 @@ Your application's metrics are scraped (pulled) from the `/metrics` endpoint and
 
 ```mermaid
 graph LR
-  Mimir --GET /metrics--> Pod
-  nais.yaml -.register target.-> Mimir
+  Alloy --GET /metrics--> Pod
+  Alloy --remote_write--> Mimir
+  nais.yaml -.register target.-> Alloy
   nais.yaml -.configure.-> Pod
 ```
 
@@ -71,7 +72,7 @@ Our ingress controller also exposes metrics about the number of requests, respon
 
 ## Debugging metrics
 
-If you're having trouble with your metrics, use the [Explore view in Grafana](<<tenant_url("grafana", "explore")>>) to test your PromQL queries. Pick the Mimir data source that matches your environment.
+If you're having trouble with your metrics, use the [Explore view in Grafana](<<tenant_url("grafana", "explore")>>) to test your PromQL queries. Pick the Prometheus data source that matches your environment.
 
 If your metrics are not showing up, you can check whether your application is being scraped by querying the `up` metric for your application in Explore:
 

--- a/docs/observability/metrics/how-to/push.md
+++ b/docs/observability/metrics/how-to/push.md
@@ -13,23 +13,23 @@ Prometheus has further explanations and examples [here](https://prometheus.io/do
 
 ???+ note ".nais/naisjob.yaml"
 
-    ```yaml hl_lines="11-18"
+    ```yaml hl_lines="10-16"
     apiVersion: nais.io/v1
     kind: Naisjob
     metadata:
-    name: <MY-JOB>
-    namespace: <MY-TEAM>
+      name: <MY-JOB>
+      namespace: <MY-TEAM>
     spec:
-    image: {{image}}
-    schedule: "*/1 * * * *"
-    env:
+      image: {{image}}
+      schedule: "*/1 * * * *"
+      env:
         - name: PUSH_GATEWAY_ADDRESS
-        value: prometheus-pushgateway.nais-system:9091
-    accessPolicy:
+          value: prometheus-pushgateway.nais-system:9091
+      accessPolicy:
         outbound:
-        rules:
+          rules:
             - application: prometheus-pushgateway
-            namespace: nais-system
+              namespace: nais-system
     ```
 
 ## Send metrics to your application

--- a/docs/observability/metrics/reference/globals.md
+++ b/docs/observability/metrics/reference/globals.md
@@ -26,7 +26,7 @@ The following labels are common to most metrics:
 The `container_memory_usage_bytes` metric tracks the amount of memory used by a container.
 
 ```promql
-container_memory_usage_bytes{container="my-application", ...}
+container_memory_usage_bytes{container="my-application"}
 ```
 
 ### CPU Usage
@@ -34,13 +34,13 @@ container_memory_usage_bytes{container="my-application", ...}
 The `container_cpu_usage_seconds_total` metric tracks the amount of CPU time used by a container.
 
 ```promql
-container_cpu_usage_seconds_total{container="my-application", ...}
+container_cpu_usage_seconds_total{container="my-application"}
 ```
 
 Since this metric is cumulative, you can calculate the rate of CPU usage by using the `rate` function.
 
 ```promql
-rate(container_cpu_usage_seconds_total{container="my-application", ...}[5m])
+rate(container_cpu_usage_seconds_total{container="my-application"}[5m])
 ```
 
 ### Limits and Requests
@@ -48,10 +48,10 @@ rate(container_cpu_usage_seconds_total{container="my-application", ...}[5m])
 The `kube_pod_container_resource_limits` and `kube_pod_container_resource_requests` metrics track the resource limits and requests for a container.
 
 ```promql
-kube_pod_container_resource_limits{resource="memory", container="my-application", ...}
-kube_pod_container_resource_requests{resource="memory", container="my-application", ...}
-kube_pod_container_resource_limits{resource="cpu", container="my-application", ...}
-kube_pod_container_resource_requests{resource="cpu", container="my-application", ...}
+kube_pod_container_resource_limits{resource="memory", container="my-application"}
+kube_pod_container_resource_requests{resource="memory", container="my-application"}
+kube_pod_container_resource_limits{resource="cpu", container="my-application"}
+kube_pod_container_resource_requests{resource="cpu", container="my-application"}
 ```
 
 ### Out of Memory (OOMKilled)
@@ -61,7 +61,7 @@ Out of memory restarts occur when a container exceeds its memory limit and the k
 The `kube_pod_container_status_terminated_reason` metric tracks the number of times a container has been terminated for various reasons, including OOM kills.
 
 ```promql
-kube_pod_container_status_terminated_reason{reason="OOMKilled", ...}
+kube_pod_container_status_terminated_reason{reason="OOMKilled"}
 ```
 
 Other reasons for container termination include `Error`, `Completed`, and `ContainerCannotRun`.

--- a/docs/observability/metrics/reference/grafana.md
+++ b/docs/observability/metrics/reference/grafana.md
@@ -36,6 +36,6 @@ A visualization is a graphical representation of your data. Grafana supports a v
 
 ## Alerting
 
-Grafana has a built-in alerting system that allows you to set up alerts for your metrics. You can create alert rules that are evaluated at regular intervals, and when the alert rule conditions are met, Grafana will send notifications to the configured notification channels.
+Grafana has a built-in alerting system that allows you to set up alerts for your metrics. You can create alert rules that are evaluated at regular intervals, and when the alert rule conditions are met, Grafana will send notifications to the configured contact points.
 
 * [Guide: Alerting in Grafana](../../alerting/how-to/grafana.md)

--- a/docs/observability/metrics/reference/metrics.md
+++ b/docs/observability/metrics/reference/metrics.md
@@ -12,4 +12,4 @@ Then you have full control of the database and retention.
 
 ## Querying metrics
 
-Query metrics using the [Explore view in Grafana](<<tenant_url("grafana", "explore")>>). Pick the Mimir data source that matches your environment (e.g. `dev`, `prod`).
+Query metrics using the [Explore view in Grafana](<<tenant_url("grafana", "explore")>>). Pick the Prometheus data source that matches your environment (e.g. `dev`, `prod`).

--- a/docs/observability/metrics/reference/otel.md
+++ b/docs/observability/metrics/reference/otel.md
@@ -30,10 +30,9 @@ Target information is exported as a set of labels, including:
 
 The OpenTelemetry SDKs and auto-instrumentation libraries export the following metrics for HTTP servers:
 
-| Metric Name                                   | Description                                                 |
-| --------------------------------------------- | ----------------------------------------------------------- |
-| `http_server_request_duration_seconds_bucket` | Duration of HTTP server requests, in seconds (java)         |
-| `http_server_duration_milliseconds_bucket`    | Duration of HTTP server requests, in milliseconds (node.js) |
+| Metric Name                                   | Description                                                     |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| `http_server_request_duration_seconds_bucket` | Duration of HTTP server requests, in seconds (java and node.js) |
 
 ## HTTP Client Metrics
 
@@ -58,9 +57,9 @@ The OpenTelemetry SDKs and auto-instrumentation libraries export the following m
 
 | Metric Name                              | Description                          |
 | ---------------------------------------- | ------------------------------------ |
-| `process_runtime_jvm_buffer_count`       | Count of JVM buffers.                |
-| `process_runtime_jvm_buffer_limit_bytes` | Limit of JVM buffer sizes, in bytes. |
-| `process_runtime_jvm_buffer_usage_bytes` | Usage of JVM buffer sizes, in bytes. |
+| `jvm_buffer_count`       | Count of JVM buffers.                |
+| `jvm_buffer_limit_bytes` | Limit of JVM buffer sizes, in bytes. |
+| `jvm_buffer_usage_bytes` | Usage of JVM buffer sizes, in bytes. |
 
 ## Kafka Metrics
 

--- a/docs/observability/tracing/README.md
+++ b/docs/observability/tracing/README.md
@@ -65,7 +65,7 @@ Below is a list of known fields you should check for your application.
 
 | Trace type | Known fields                                        |
 |------------|-----------------------------------------------------|
-| HTTP       | `url.path`, `target.path`, `route.path`, `url.full` |
+| HTTP       | `url.path`, `http.route`, `url.full`                |
 | Valkey     | `db.statement`                                      |
 | Postgres   | `db.statement`                                      |
 | Kafka      | `messaging.kafka.message.key`                       |

--- a/docs/observability/tracing/how-to/correlate-traces-logs.md
+++ b/docs/observability/tracing/how-to/correlate-traces-logs.md
@@ -9,7 +9,7 @@ This guide explains how to correlate traces with logs in Grafana Tempo. When set
 ## Prerequisites
 
 1. [Auto-instrumentation enabled](../../how-to/auto-instrumentation.md) (or manual OTel SDK setup)
-2. [Logs sent to Grafana Loki](../../logging/how-to/loki.md#enable-logging-to-grafana-loki)
+2. [Logs sent to Grafana Loki](../../logging/how-to/loki.md#default-logging-with-grafana-loki)
 
 ## How it works
 

--- a/docs/observability/tracing/reference/span-metrics.md
+++ b/docs/observability/tracing/reference/span-metrics.md
@@ -23,9 +23,9 @@ Span metrics include a rich set of labels (dimensions) for detailed analysis. No
 | service_name               | General           | The name of the service executing the operation.                |
 | service_namespace          | General           | The namespace in which the service is deployed.                 |
 | k8s_cluster_name           | General           | The name of the Kubernetes cluster hosting the service.         |
-| span_kind                  | General           | The kind of span (e.g., SERVER, CLIENT, PRODUCER, CONSUMER).    |
+| span_kind                  | General           | The kind of span (e.g., `SPAN_KIND_SERVER`, `SPAN_KIND_CLIENT`, `SPAN_KIND_PRODUCER`, `SPAN_KIND_CONSUMER`). |
 | span_name                  | General           | The name of the span, typically the operation or endpoint name. |
-| status_code                | General           | The status code of the span (e.g., OK, ERROR, UNSET).           |
+| status_code                | General           | The status code of the span (e.g., `STATUS_CODE_OK`, `STATUS_CODE_ERROR`, `STATUS_CODE_UNSET`). |
 | server_address             | HTTP              | The address of the server handling the request.                 |
 | http_status_code           | HTTP              | The HTTP status code returned for the request.                  |
 | http_response_status_code  | HTTP              | An alternative label for the HTTP response status code.         |
@@ -38,6 +38,10 @@ Span metrics include a rich set of labels (dimensions) for detailed analysis. No
 | messaging_operation        | Messaging (Async) | The operation performed on the messaging system.                |
 
 These labels help in analyzing metrics by service, namespace, cluster, span kind, span name, status code, HTTP status, database, messaging system, and more.
+
+!!! note "Sparse dimensions"
+
+    `http_host`, `db_name`, and the `messaging_*` labels are configured as span-metric dimensions, but they are only populated when the underlying span carries the corresponding attribute. In practice they are sparse, so example queries that filter on them may return empty results.
 
 ## Span Name
 
@@ -53,10 +57,10 @@ Key recommendations for span names:
 
 Metrics are collected only for specific span kinds as defined by the OpenTelemetry specification. These include:
 
-- **SERVER**: For server-side handling of requests (e.g., an HTTP server receiving a request).
-- **CLIENT**: For client-side operations (e.g., outbound HTTP or database requests).
-- **PRODUCER**: For sending messages to messaging systems (e.g., publishing to a Kafka topic).
-- **CONSUMER**: For receiving messages from messaging systems (e.g., reading from a Kafka topic).
+- **`SPAN_KIND_SERVER`**: For server-side handling of requests (e.g., an HTTP server receiving a request).
+- **`SPAN_KIND_CLIENT`**: For client-side operations (e.g., outbound HTTP or database requests).
+- **`SPAN_KIND_PRODUCER`**: For sending messages to messaging systems (e.g., publishing to a Kafka topic).
+- **`SPAN_KIND_CONSUMER`**: For receiving messages from messaging systems (e.g., reading from a Kafka topic).
 
 Spans with a resource attribute `resource.service.name` equal to `nais-ingress` are excluded from metrics to ensure that only application-relevant data is recorded.
 
@@ -64,9 +68,9 @@ Spans with a resource attribute `resource.service.name` equal to `nais-ingress` 
 
 Span status indicates the outcome of an operation, providing context for troubleshooting. The common span status codes are:
 
-- **OK**: The span completed successfully.
-- **ERROR**: An error occurred during the span's execution.
-- **UNSET**: No explicit status was set, indicating an undefined state.
+- **`STATUS_CODE_OK`**: The span completed successfully.
+- **`STATUS_CODE_ERROR`**: An error occurred during the span's execution.
+- **`STATUS_CODE_UNSET`**: No explicit status was set, indicating an undefined state.
 
 Monitoring span status alongside other metrics can quickly identify issues related to failed operations or unexpected behavior.
 

--- a/docs/observability/tracing/reference/trace-semconv.md
+++ b/docs/observability/tracing/reference/trace-semconv.md
@@ -4,4 +4,68 @@ tags: [reference, otel, observability, tracing]
 
 # OpenTelemetry Trace Semantic Conventions
 
-OpenTelemetry Trace Semantic Conventions can be found at [opentelemetry.io](https://opentelemetry.io/docs/specs/semconv/general/trace/).
+OpenTelemetry Semantic Conventions define a common set of attribute names for spans, so that traces from different languages and libraries can be queried and correlated consistently. This page lists the attributes you are most likely to encounter on traces collected by the Nais platform.
+
+The full specification is maintained upstream at [opentelemetry.io](https://opentelemetry.io/docs/specs/semconv/general/trace/).
+
+!!! note "Legacy attribute names"
+
+    OpenTelemetry stabilized several attribute names over time. The auto-instrumentation agents on the platform still emit some of the older names — notably `http.status_code`, `db.statement`, and `db.operation` — alongside their stabilized replacements (`http.response.status_code`, `db.query.text`, and `db.operation.name`). When writing queries, be prepared to check for both the legacy and the stabilized attribute.
+
+## Resource attributes
+
+Resource attributes describe the entity producing the telemetry (your workload) and are attached to every span it emits.
+
+| Attribute               | Description                                             | Example              |
+| ----------------------- | ------------------------------------------------------- | -------------------- |
+| `service.name`          | The name of the service (your application name).        | `my-app`             |
+| `service.namespace`     | The namespace (team) the service is deployed in.        | `my-team`            |
+| `k8s.cluster.name`      | The Kubernetes cluster hosting the workload.            | `prod-gcp`           |
+| `telemetry.sdk.language`| The language of the SDK that produced the span.         | `java`               |
+
+## HTTP attributes
+
+Set on spans that represent HTTP server or client calls.
+
+| Attribute                    | Status     | Description                                          | Example         |
+| ---------------------------- | ---------- | ---------------------------------------------------- | --------------- |
+| `http.request.method`        | Stable     | The HTTP request method.                             | `GET`           |
+| `http.response.status_code`  | Stable     | The HTTP response status code.                       | `200`           |
+| `http.route`                 | Stable     | The matched route (template), low cardinality.       | `/users/{id}`   |
+| `url.path`                   | Stable     | The path component of the request URL.               | `/users/42`     |
+| `url.full`                   | Stable     | The full request URL.                                | `https://…/users/42` |
+| `server.address`             | Stable     | The address of the server handling the request.      | `api.example.com` |
+| `http.status_code`           | Legacy     | Superseded by `http.response.status_code`.           | `200`           |
+
+## Database attributes
+
+Set on spans that represent calls to a database.
+
+| Attribute            | Status | Description                                              | Example              |
+| -------------------- | ------ | -------------------------------------------------------- | -------------------- |
+| `db.system`          | Stable | The database management system.                          | `postgresql`         |
+| `db.namespace`       | Stable | The name of the database being accessed.                 | `orders`             |
+| `db.operation.name`  | Stable | The database operation being executed.                   | `SELECT`             |
+| `db.query.text`      | Stable | The database statement being executed.                   | `SELECT * FROM …`    |
+| `db.name`            | Legacy | Superseded by `db.namespace`.                            | `orders`             |
+| `db.operation`       | Legacy | Superseded by `db.operation.name`.                       | `SELECT`             |
+| `db.statement`       | Legacy | Superseded by `db.query.text`.                           | `SELECT * FROM …`    |
+
+## Messaging attributes
+
+Set on spans that represent producing or consuming messages (e.g. Kafka).
+
+| Attribute                     | Description                                        | Example                |
+| ----------------------------- | -------------------------------------------------- | ---------------------- |
+| `messaging.system`            | The messaging system.                              | `kafka`                |
+| `messaging.destination.name`  | The topic or queue name.                           | `my-team.some-topic`   |
+| `messaging.operation`         | The operation performed on the message.            | `publish`              |
+| `messaging.kafka.message.key` | The Kafka message key.                             | `order-42`             |
+
+!!! warning "Sensitive data"
+
+    Some of these attributes (for example `url.path`, `db.statement`, and `messaging.kafka.message.key`) can contain user data. See [Sensitive data](../README.md#sensitive-data) for what to check in your application.
+
+## Attribute names in span metrics
+
+When trace attributes are turned into [span metrics](span-metrics.md), Prometheus replaces every `.` (dot) in the attribute name with an `_` (underscore) — for example `http.response.status_code` becomes the `http_response_status_code` label.

--- a/docs/observability/tracing/reference/traceql.md
+++ b/docs/observability/tracing/reference/traceql.md
@@ -43,7 +43,7 @@ Similar to PromQL, TraceQL supports a set of operators for comparing span attrib
 
 Since a trace can be composed of multiple spans, multiple selectors can be used together to filter spans based on different attributes.
 
-TraceQL supports two types of combining spansets: logical (`&&` and `||`) and structural relations (`>`, `>\>`, `<\<` `<`, and `~`).
+TraceQL supports two types of combining spansets: logical (`&&` and `||`) and structural relations (`>`, `>>`, `<<`, `<`, and `~`).
 
 ##### Logical
 
@@ -53,15 +53,15 @@ The logical operators `&&` and `||` are used to combine spansets based on their 
 { resource.service.name="server" } && { resource.service.name="client" }
 ```
 
-The above query will return traces where a span with the service name `server` and a differ3ent span with the service name `client` are present.
+The above query will return traces where a span with the service name `server` and a different span with the service name `client` are present.
 
 ##### Structural
 
 Structural relations are used to filter spans based on their structural relationships. The structural relations are:
 
 - `>` - Direct parent of
-- `>\>` - Ancestor of
-- `<\<` - Descendant of
+- `>>` - Ancestor of
+- `<<` - Descendant of
 - `<` - Direct child of
 - `~` - Sibling of
 


### PR DESCRIPTION
Fixes verified review findings in the metrics and tracing observability docs. All changes are cosmetic/accuracy corrections verified against live Mimir and the Tempo config.

## Metrics (`docs/observability/metrics/`)
- **otel.md** — live metric names: `process_runtime_jvm_buffer_*` → `jvm_buffer_*`; collapsed the java-seconds/node-ms HTTP-server split into the single `http_server_request_duration_seconds_*` both now emit. (`db_client_connections_*` left as-is.)
- **how-to/push.md** — re-indented the Naisjob YAML manifest to valid nesting under `metadata:`/`spec:`.
- **reference/globals.md** — removed invalid literal `...` from PromQL label selectors.
- **reference/grafana.md** — "notification channels" → "contact points" (unified alerting).
- **README.md** — mermaid diagram now shows **Alloy** scraping `/metrics` and remote-writing to **Mimir**; datasource wording standardized to "Prometheus".
- **reference/metrics.md** — "Mimir data source" → "Prometheus".

## Tracing (`docs/observability/tracing/`)
- **reference/span-metrics.md** — `span_kind`/`status_code` values use full enum form (`SPAN_KIND_SERVER`, `STATUS_CODE_ERROR`, …); added a caveat that `http_host`/`db_name`/`messaging_*` are configured but sparse. Metric names and dimension labels left untouched (verified correct).
- **reference/trace-semconv.md** — populated the empty stub into a real reference of resource/HTTP/database/messaging attributes, noting the legacy names (`http.status_code`, `db.statement`, `db.operation`) still emitted alongside stabilized ones.
- **how-to/correlate-traces-logs.md** — fixed dead anchor → `loki.md#default-logging-with-grafana-loki`.
- **README.md** — masking table uses real OTel names (`http.route`, `url.path`) instead of `target.path`/`route.path`.
- **reference/traceql.md** — fixed "differ3ent" typo and the escaped `>\>`/`<\<` operators (now `>>`/`<<`).

## Verification
- `mise run build nav ssb` — green.
- Links on changed pages verified (loki anchor and the new `README.md#sensitive-data` / `span-metrics.md` links resolve).