### PR TITLE
docs(observability): fix alerting + cross-cutting review findings

### DIFF
--- a/docs/observability/alerting/how-to/prometheus-advanced.md
+++ b/docs/observability/alerting/how-to/prometheus-advanced.md
@@ -44,7 +44,7 @@ For more information about `slackConfigs` and other posibilites see the [Prometh
                 sla: "no need to respond"
               labels:
                 severity: "info"
-                special_type_to_use_in_alertmanager_config: myteam-testing
+                special_type_to_use_in_alertmanager_config: <MYTEAM-TESTING>
                 alert_type: custom
     ```
 
@@ -101,7 +101,7 @@ Here is a basic example with a single alert (that always trigger to make this ea
                   {{- else if eq .CommonLabels.severity "info" -}}
                     #36c5f0
                   {{- else -}}
-                    .CommonLabels.severity
+                    {{ .CommonLabels.severity }}
                   {{- end -}}
                 {{ else -}}
                 good

--- a/docs/observability/alerting/reference/prometheusrule.md
+++ b/docs/observability/alerting/reference/prometheusrule.md
@@ -11,12 +11,12 @@ tags: [reference, observability, alerting, prometheus]
 
 Prometheus alerts are defined using the [PromQL](../../metrics/reference/promql.md) query language. The query language is used to specify when an alert should fire, and the `PrometheusRule` resource is used to specify the alert and its properties.
 
-Prometheus alerts are sent to the team's Slack channel configured in [Nais Console](../../../operate/console.md) when the alert fires.
+Prometheus alerts are sent to the team's Slack channel configured in [Nais Console](../../../operate/console/README.md) when the alert fires.
 
 ```mermaid
 graph LR
-  alerts.yaml --> Prometheus
-  Prometheus --> Alertmanager
+  alerts.yaml --> Mimir
+  Mimir --> Alertmanager
   Alertmanager --> Slack
 ```
 
@@ -42,19 +42,21 @@ graph LR
         rules:
           - alert: HttpClientErrorRateHigh
             expr: |
-              1 - (
-                sum(
-                  rate(
-                    http_client_request_duration_seconds_count{app="my-app", http_response_status_code="200"}[5m]
-                  )
-                ) by (server_address)
-                /
-                sum(
-                  rate(
-                    http_client_request_duration_seconds_count{app="my-app"}[5m]
-                  )
-                ) by (server_address)
-              ) * 100 < 95
+              (
+                1 - (
+                  sum(
+                    rate(
+                      http_client_request_duration_seconds_count{app="my-app", http_response_status_code="200"}[5m]
+                    )
+                  ) by (server_address)
+                  /
+                  sum(
+                    rate(
+                      http_client_request_duration_seconds_count{app="my-app"}[5m]
+                    )
+                  ) by (server_address)
+                )
+              ) * 100 > 5
             for: 10m
             annotations:
               summary: "High error rate for outbound http requests"

--- a/docs/observability/how-to/auto-instrumentation.md
+++ b/docs/observability/how-to/auto-instrumentation.md
@@ -8,7 +8,7 @@ tags: [how-to, tracing, observability]
 Auto-instrumentation injects an [OpenTelemetry](https://opentelemetry.io/) agent into your application at startup.
 The agent hooks into popular libraries and frameworks to collect [traces](../tracing/README.md) and runtime metrics — without code changes. Log export via OpenTelemetry is [available as an opt-in](../reference/auto-config.md#logs-auto-instrumentation).
 
-Supported runtimes: **Java/Kotlin**, **Node.js**, **Python**, and **SDK-only** mode for Go and other languages that provide their own OpenTelemetry setup.
+Supported runtimes: **Java/Kotlin**, **Node.js**, **Python**, **.NET**, and **SDK-only** mode for Go and other languages that provide their own OpenTelemetry setup.
 
 ## What you get
 
@@ -57,6 +57,16 @@ Add the following to your `nais.yaml` and deploy:
         autoInstrumentation:
           enabled: true
           runtime: python
+    ```
+
+=== ".NET"
+
+    ```yaml
+    spec:
+      observability:
+        autoInstrumentation:
+          enabled: true
+          runtime: dotnet
     ```
 
 === "SDK only (Go, etc.)"

--- a/docs/observability/reference/auto-config.md
+++ b/docs/observability/reference/auto-config.md
@@ -101,15 +101,15 @@ The OpenTelemetry Agent is used to automatically instrument your application. Th
 
 | Runtime  | Agent Version          | SDK Version  |
 | -------- | ---------------------- | ------------ |
-| `java`   | [2.22.0][java-agent]   | 1.55.0       |
-| `nodejs` | [0.67.0][nodejs-agent] | 0.208.0      |
-| `python` | [0.51b0][python-agent] | 1.30.0       |
-| `dotnet` | 1.12.0                 |              |
+| `java`   | [2.28.1][java-agent]   | 1.62.0       |
+| `nodejs` | [0.77.0][nodejs-agent] | 0.219.0      |
+| `python` | [0.63b1][python-agent] | 1.42.1       |
+| `dotnet` | [1.15.0][dotnet-agent] |              |
 
-[java-agent]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.22.0
-[nodejs-agent]: https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.67.0
-[python-agent]: https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.51b0
-[dotnet-agent]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.12.0
+[java-agent]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.28.1
+[nodejs-agent]: https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.77.0
+[python-agent]: https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.63b1
+[dotnet-agent]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0
 
 ## Java Agent
 

--- a/docs/observability/reference/glossary.md
+++ b/docs/observability/reference/glossary.md
@@ -18,7 +18,7 @@ Metrics are a numerical measurement of something in your application such as the
 
 ### Alertmanager
 
-[Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) is a component of Prometheus that is used to create and manage Slack alerts based on the metrics collected by Prometheus.
+[Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) is a component of Prometheus that routes, deduplicates, and groups alert notifications sent by Prometheus (or the Mimir ruler) and delivers them to receivers such as Slack.
 
 ### Grafana
 

--- a/docs/observability/tutorials/getting-started.md
+++ b/docs/observability/tutorials/getting-started.md
@@ -21,7 +21,7 @@ spec:
   observability:
     autoInstrumentation:
       enabled: true
-      runtime: java  # or: nodejs, python, sdk
+      runtime: java  # or: nodejs, python, dotnet, sdk
 ```
 
 Nais injects the OpenTelemetry agent at startup. No code changes needed.


### PR DESCRIPTION
Fixes verified review findings across the alerting and cross-cutting observability docs.

## Changes

**`alerting/reference/prometheusrule.md`**
- Fixed the flagship example alert expression, which was logically inverted. PromQL operator precedence parsed `1 - ( success/total ) * 100 < 95` as `(1 - (successRatio * 100)) < 95`, which is true for every series always. Reframed as an error-rate check `( 1 - success/total ) * 100 > 5`, which matches the `HttpClientErrorRateHigh` name, the "high error rate" summary, and the `failing at {{ $value }}%` message. Validated with `promtool check rules` (SUCCESS).
- Fixed dead link `../../../operate/console.md` -> `../../../operate/console/README.md`.
- Aligned the pipeline diagram on the Mimir-ruler path (`alerts.yaml -> Mimir -> Alertmanager`), matching `observability/README.md`; the old `Prometheus -> Alertmanager` was stale.

**`observability/how-to/auto-instrumentation.md` + `observability/tutorials/getting-started.md`**
- Added the `.NET` (`runtime: dotnet`) runtime to the supported list/tabs. It is supported by naiserator's enum and its agent version is documented in `auto-config.md`.

**`observability/reference/auto-config.md`**
- Refreshed stale auto-instrumentation agent versions from the opentelemetry-collector chart's `values.yaml`: java `2.22.0 -> 2.28.1`, nodejs `0.67.0 -> 0.77.0`, python `0.51b0 -> 0.63b1`, dotnet `1.12.0 -> 1.15.0`; updated the matching SDK versions (java `1.62.0`, nodejs `0.219.0`, python `1.42.1`) and release links, and linked the dotnet version.

**`observability/reference/glossary.md`**
- Fixed the Alertmanager link (added `/latest/`) and tightened the definition: Alertmanager routes, deduplicates, and groups notifications; it does not collect metrics or create alerts.

**`alerting/how-to/prometheus-advanced.md`**
- Made the `special_type_to_use_in_alertmanager_config` label value match its route matcher (both `<MYTEAM-TESTING>`).
- Fixed the `.CommonLabels.severity` template fallback that emitted the literal string instead of `{{ .CommonLabels.severity }}`.

## Verification
- `mise run build nav ssb` green.
- Corrected PromQL validated with `promtool check rules` (SUCCESS).
- Changed-page links resolve (no new broken-link warnings in the build).