### PR TITLE
docs(apm): backend exceptions how-to — add Node.js, Go, and the thin-error anti-pattern

### DIFF
--- a/docs/observability/apm/how-to/backend-exceptions-as-issues.md
+++ b/docs/observability/apm/how-to/backend-exceptions-as-issues.md
@@ -1,9 +1,10 @@
 ---
 title: Get backend exceptions into Issues
 description: >-
-  Send your Spring Boot or Ktor exceptions over OpenTelemetry so they land in
-  the Nais APM Issues tab as first-class, well-grouped backend issues — with the
-  full stack trace and pod impact — instead of sampled plain-text log lines.
+  Send your backend exceptions — from JVM (Spring Boot, Ktor), Node.js, and Go
+  services — over OpenTelemetry so they land in the Nais APM Issues tab as
+  first-class, well-grouped backend issues with the stack trace and pod impact,
+  instead of sampled plain-text log lines.
 tags: [how-to, observability, apm, logging]
 ---
 
@@ -11,10 +12,10 @@ tags: [how-to, observability, apm, logging]
 
 The Nais APM **Issues** tab groups your service's backend exceptions from Loki.
 How good that grouping is depends entirely on *how the exception reaches Loki*.
-This guide shows how to get JVM exceptions (Spring Boot and Ktor) into the
-**richest** shape: OpenTelemetry semantic-convention exception metadata, so each
-exception becomes a first-class issue with its type, message, full stack trace,
-and pod impact.
+This guide shows how to get backend exceptions — from JVM (Spring Boot and
+Ktor), Node.js, and Go services — into the **richest** shape: OpenTelemetry
+semantic-convention exception metadata, so each exception becomes a first-class
+issue with its type, message, stack trace, and pod impact.
 
 ## Why the log shape matters
 
@@ -68,6 +69,13 @@ throwable is enough.
     that routes to them). Spring Boot and Ktor both use SLF4J + Logback by
     default, so the exact same two steps below work for both: enable OTLP log
     export, and log exceptions *with the throwable*.
+
+!!! note "Node.js is automatic too; Go is manual"
+    Node.js reaches shape A the same way — the auto-instrumentation's Winston or
+    Pino appender attaches `exception.*` when you log an `Error` object (see
+    [Node.js and Express](#nodejs-and-express)). Go has **no** platform agent and
+    no automatic error mapping, so you set the `exception.*` attributes yourself
+    (see [Go (net/http)](#go-nethttp)).
 
 ## Spring Boot (Kotlin / Java)
 
@@ -179,6 +187,245 @@ try {
     you'll stay in shape C. Logback is the Ktor default, so most apps already
     have it.
 
+## Node.js and Express
+
+Node has no bytecode agent like the JVM, but the `runtime: nodejs`
+[auto-instrumentation](../../how-to/auto-instrumentation.md) is the OpenTelemetry
+Node SDK plus the auto-instrumentations bundle — and that bundle includes the
+**Winston** and **Pino** instrumentations. Each of those has a log-sending
+appender that forwards your log records into the OTel logs pipeline, and on
+current versions it maps a logged `Error` onto the semantic-convention
+`exception.*` attributes for you. So the recipe is the same two steps: enable
+OTLP log export, and log the **`Error` object** — never a preformatted string.
+
+### 1. Enable auto-instrumentation and OTLP log export
+
+```yaml title="nais.yaml"
+spec:
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: nodejs
+  env:
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
+```
+
+Setting `OTEL_LOGS_EXPORTER=otlp` is what makes the Node SDK configure a logs
+provider for the Winston/Pino appenders to emit into; log sending is on by
+default once that provider exists.
+
+### 2. Log the `Error` object
+
+Pass the `Error` itself so the appender can read its name, message, and stack —
+don't interpolate it into the message string.
+
+With **Pino**, put the error under the `err` key (Pino's default error key):
+
+```javascript
+// GOOD — the Error under `err` → exception.type/message/stacktrace,
+// and `orderId` rides along as a structured attribute
+logger.error({ err, orderId: order.id }, "Failed to process order");
+
+// BAD — a preformatted string: no type, no stack → shape B
+// logger.error(`Failed to process order ${order.id}: ${err.message}`);
+```
+
+With **Winston**, pass the error alongside the message:
+
+```javascript
+// GOOD — the Error is picked up from the log arguments → exception.* attributes
+logger.error("Failed to process order", { orderId: order.id, err });
+
+// BAD — string interpolation, no exception metadata → shape B
+// logger.error(`Failed to process order ${order.id}: ${err.message}`);
+```
+
+The natural place to catch what escapes your routes is the Express
+**error-handling middleware** — the four-argument handler `(err, req, res, next)`,
+registered after all your routes:
+
+```javascript
+app.use((err, req, res, next) => {
+    logger.error({ err }, "Unhandled error"); // Winston: logger.error("Unhandled error", { err })
+    res.status(500).send("Internal Server Error");
+});
+```
+
+!!! note "Check your OpenTelemetry versions"
+    The automatic `Error` → `exception.*` mapping is a recent addition
+    (OpenTelemetry JS `api-logs`/`sdk-logs` ≥ 0.212.0, which the platform's
+    `nodejs` agent bundles). On older self-managed pins the `Error` was copied as
+    a generic attribute instead, leaving you in shape B. If you emit your own log
+    records with `@opentelemetry/api-logs`, you can set it explicitly by passing
+    the error as the record's `exception` field:
+    `logger.emit({ severityNumber: SeverityNumber.ERROR, body: err.message, exception: err })`.
+
+## Go (net/http)
+
+Go is different in two ways, and it's worth being honest about both.
+
+First, there is **no Go agent**. The `runtime: sdk`
+[auto-instrumentation](../../how-to/auto-instrumentation.md) mode sets the
+OpenTelemetry environment variables (including the OTLP endpoint) but injects
+nothing into your process — your app wires the OpenTelemetry SDK itself, so you
+configure the logs pipeline in code.
+
+Second, **nothing maps a Go `error` to `exception.*` for you**, and a Go `error`
+carries no stack trace the way a Java `Throwable` does. You can still reach shape
+A on `exception.type` and `exception.message` — which is what the Issues tab
+groups on — but you set those attributes yourself, and a real stack trace takes
+extra work.
+
+### 1. Wire the logs SDK and bridge `slog` to it
+
+Build a `LoggerProvider` with the OTLP log exporter and route `slog` through the
+[`otelslog`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog)
+bridge. The OpenTelemetry Go **logs** signal is still beta (`v0.x` modules), but
+it is usable in production:
+
+```go
+import (
+    "context"
+    "log/slog"
+
+    "go.opentelemetry.io/contrib/bridges/otelslog"
+    "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+    sdklog "go.opentelemetry.io/otel/sdk/log"
+    "go.opentelemetry.io/otel/sdk/resource"
+)
+
+func setupLogging(ctx context.Context, res *resource.Resource) (*sdklog.LoggerProvider, error) {
+    // otlploggrpc reads the OTEL_EXPORTER_OTLP_* env vars that `runtime: sdk` injects.
+    exporter, err := otlploggrpc.New(ctx)
+    if err != nil {
+        return nil, err
+    }
+    provider := sdklog.NewLoggerProvider(
+        sdklog.WithResource(res), // the same resource you build for traces (service.name / namespace)
+        sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
+    )
+    // Route the standard-library slog through the bridge.
+    slog.SetDefault(otelslog.NewLogger("my-app", otelslog.WithLoggerProvider(provider)))
+    return provider, nil // remember to defer provider.Shutdown(ctx)
+}
+```
+
+### 2. Log the error with `exception.*` attributes
+
+The bridge copies `slog` attribute keys through verbatim and does **not**
+special-case errors — so name the attributes with the exact semantic-convention
+keys and they land as the `exception_type` / `exception_message` structured
+metadata the Issues tab needs:
+
+```go
+func handleOrder(w http.ResponseWriter, r *http.Request) {
+    if err := processOrder(r.Context(), order); err != nil {
+        // GOOD — exception.type + exception.message → shape A grouping,
+        // order.id rides along as its own structured attribute
+        slog.ErrorContext(r.Context(), "failed to process order",
+            slog.String("order.id", order.ID),
+            slog.String("exception.type", fmt.Sprintf("%T", err)),
+            slog.String("exception.message", err.Error()),
+        )
+
+        // BAD — the error folded into the message: no type, fragmented grouping → shape B
+        // slog.Error("failed to process order " + order.ID + ": " + err.Error())
+
+        http.Error(w, "internal error", http.StatusInternalServerError)
+        return
+    }
+}
+```
+
+!!! warning "Stack traces are weaker in Go — be realistic"
+    A Go `error` has no stack, so `exception.stacktrace` is **not** populated for
+    you. If you need it you must capture it yourself with `runtime.Stack`, but
+    that gives the *current* goroutine's stack at the log call — not where the
+    error originated — so it's far less useful than a JVM stack trace. An error
+    library that records a stack at creation (for example `pkg/errors` or
+    `cockroachdb/errors`) is a better source; format its stack into
+    `slog.String("exception.stacktrace", …)`. Separately,
+    `span.RecordError(err, trace.WithStackTrace(true))` records the exception on
+    the current **span** (visible in the trace), independent of the log record
+    above. Type + message alone is still enough to land in shape A.
+
+## Log the exception, not a bare message
+
+This is the single biggest reason backend Issues come out thin, and it applies to
+every runtime above. Everything hinges on one habit: **hand the logging framework
+the throwable/error object, not a string you built from it.** The moment you
+pre-format the error into the message, its type and stack are gone and Loki only
+ever sees text — you drop from shape A to shape B (or, on stdout, shape C).
+
+### Log the object, never a pre-formatted string
+
+Bad first, good second, per runtime:
+
+**JVM (Kotlin)**
+
+```kotlin
+// BAD  — type and stack lost inside a string
+log.warn("Failed to fetch $url: ${e.message}")
+// GOOD — throwable as the last argument, url as a parameter
+log.warn("Failed to fetch {}", url, e)
+```
+
+**Node.js (Pino)**
+
+```javascript
+// BAD
+logger.warn(`Failed to fetch ${url}: ${err.message}`);
+// GOOD
+logger.warn({ err, url }, "Failed to fetch");
+```
+
+**Go**
+
+```go
+// BAD
+slog.Warn("failed to fetch " + url + ": " + err.Error())
+// GOOD
+slog.Warn("failed to fetch",
+    slog.String("url", url),
+    slog.String("exception.type", fmt.Sprintf("%T", err)),
+    slog.String("exception.message", err.Error()),
+)
+```
+
+### Don't log self-healing retries at error or warn
+
+A message that logs on every retry and then recovers is still counted as an
+Issue — often a *top* Issue — even though nothing was ever actually broken. Log
+retries at `info`/`debug`, and only escalate to `error` when the **final**
+attempt fails:
+
+```javascript
+async function fetchWithRetry(url, attempts = 3) {
+    for (let i = 1; i <= attempts; i++) {
+        try {
+            return await fetch(url);
+        } catch (err) {
+            if (i === attempts) {
+                // only the terminal failure becomes an Issue
+                logger.error({ err, url, attempts }, "Fetch failed after retries");
+                throw err;
+            }
+            // transient, self-healing — not an Issue
+            logger.debug({ url, attempt: i }, "Fetch failed, retrying");
+        }
+    }
+}
+```
+
+### Put context in attributes, not in the message
+
+Add identifiers and status as **structured fields** (`url`, `status`, `orderId`)
+rather than concatenating them into the message string. Two payoffs: they become
+queryable structured metadata in Loki, and — because the Issues tab groups on
+message + type — keeping variable data out of the message stops one error from
+fragmenting into dozens of near-duplicate issues.
+
 ## Field mapping
 
 What the app produces, and how it lands in the Issues tab:
@@ -218,8 +465,10 @@ sum by (exception_type, exception_message) (
    trace, and a pod-impact count.
 
 If you see the log lines but no `exception_*` metadata, the event was logged
-*without* the throwable (or via a non-Logback/Log4j binding) — revisit step 2 of
-the relevant section.
+without the error object — on the JVM, without the throwable or via a
+non-Logback/Log4j binding; on Node.js, as a preformatted string instead of the
+`Error`; on Go, without the `exception.*` attributes — so revisit step 2 of the
+relevant section.
 
 ## Known limitations and cost
 
@@ -229,7 +478,8 @@ the relevant section.
   increases log volume (and cost). Keep your console logging lean when you turn
   this on.
 - **A possible duplicate issue.** If your stdout logging is JSON (for example
-  logstash-logback-encoder) *and* you enable OTLP export, the same exception can
+  logstash-logback-encoder on the JVM, or Pino/Winston JSON on Node.js) *and* you
+  enable OTLP export, the same exception can
   surface as **two** issues: the rich shape-A issue (from the OTLP copy) and a
   weaker message-only shape-B issue (from the stdout JSON copy). This is a known
   rough edge — see the platform follow-up below.

--- a/docs/observability/apm/how-to/backend-exceptions-as-issues.md
+++ b/docs/observability/apm/how-to/backend-exceptions-as-issues.md
@@ -1,21 +1,23 @@
 ---
 title: Get backend exceptions into Issues
 description: >-
-  Send your backend exceptions — from JVM (Spring Boot, Ktor), Node.js, and Go
-  services — over OpenTelemetry so they land in the Nais APM Issues tab as
-  first-class, well-grouped backend issues with the stack trace and pod impact,
-  instead of sampled plain-text log lines.
+  Get your backend exceptions — JVM (Spring Boot, Ktor) and Node.js — into the
+  Nais APM Issues tab with tight grouping and a stack trace, whether you log to
+  stdout (the default) or export logs over OpenTelemetry.
 tags: [how-to, observability, apm, logging]
 ---
 
 # Get backend exceptions into Issues
 
 The Nais APM **Issues** tab groups your service's backend exceptions from Loki.
-How good that grouping is depends entirely on *how the exception reaches Loki*.
-This guide shows how to get backend exceptions — from JVM (Spring Boot and
-Ktor), Node.js, and Go services — into the **richest** shape: OpenTelemetry
-semantic-convention exception metadata, so each exception becomes a first-class
-issue with its type, message, stack trace, and pod impact.
+How good that grouping is depends entirely on *how the exception reaches Loki* —
+and in particular on which of the two log-ingest paths your app uses.
+
+Most nais apps ship logs the default way — **stdout → fluentbit → Loki** — and
+deliberately do **not** enable OpenTelemetry log export (they keep control of
+stdout, often to multi-ship some logs elsewhere). So this guide leads with
+getting the best possible Issues on that default path, then covers the
+OpenTelemetry option that unlocks the richest shape.
 
 ## Why the log shape matters
 
@@ -27,62 +29,103 @@ Nais APM reads three shapes of backend exception from Loki, best to worst:
 | **B — JSON body** | A JSON log line with `message`/`msg` and an error-class `level` | Grouped by message only (no type), counted per occurrence. |
 | **C — plain text** | A multi-line stack trace printed to stdout | **Weak.** Sampled, not fully counted, grouped on the lead line — lossy. |
 
-Most JVM apps log a `Throwable` as a **plain multi-line stack trace to stdout**.
-The platform's log collector (fluentbit) ships stdout to Loki verbatim — it does
-**not** parse a Java stack trace back into exception fields — so those apps land
-in **shape C** and get weak, sampled issues.
+## Which path do your logs take?
 
-To reach **shape A** you have to hand the platform the exception as *structured
-data*, not as printed text. The only path that does that today is sending your
-logs over **OpenTelemetry (OTLP)**.
+Your ceiling is set by **how your logs get into Loki**, not by your logging code
+alone:
 
-## How the OTLP path produces shape A
+| Path | What Loki gets | Best shape reachable |
+|------|----------------|----------------------|
+| **stdout → fluentbit → Loki** (default) | The raw line as the log **body**. fluentbit attaches only Kubernetes fields (`service_name`, `service_namespace`, `k8s_cluster_name` as labels; pod/node/container/collector as structured metadata). It does **not** parse your JSON or promote app fields like `exception_type`. | **Shape B** — the Issues tab parses your JSON body with a `json` stage at query time and groups by message. |
+| **OpenTelemetry log export** (opt-in) | Each log-record attribute — including `exception.*` — stored as **structured metadata** by Loki's OTLP endpoint. | **Shape A** — grouped by type + message, with the class and full stack. |
 
-```mermaid
-graph LR
-  App["App logs an exception<br/>logger.error(msg, throwable)"]
-  Agent["OTel Java agent<br/>Logback/Log4j → OTel logs"]
-  Coll["OpenTelemetry collector"]
-  Loki["Loki<br/>exception_* structured metadata"]
-  APM["Nais APM Issues"]
-  App --> Agent -->|OTLP| Coll -->|OTLP| Loki --> APM
+So on the default stdout path, **shape B is the ceiling**: an `exception_type`
+field *inside* your JSON body is never promoted to a label, and shape A selects
+on `exception_type != ""` as structured metadata — so it can only match logs that
+arrived over OpenTelemetry.
+
+## Get the best Issues over stdout (shape B)
+
+This is the path most teams are on. Three habits get you the tightest, most
+useful backend Issues that Loki can give you without OpenTelemetry.
+
+### 1. Log structured JSON
+
+Shape B is parsed with `| json`, so your stdout lines must be JSON with a
+`message` (or `msg`) field and an error-class `level`. Use your framework's JSON
+encoder:
+
+- **JVM (Spring Boot / Ktor):** `logstash-logback-encoder`.
+- **Node.js (Express / Next.js):** Pino or Winston in JSON mode.
+
+### 2. Keep the error message a stable literal
+
+Shape B groups by the **message**. If you interpolate a case id, URL, or count
+into the message, every occurrence becomes its own group and one error fragments
+into dozens of near-duplicate Issues. Keep the message a fixed string and put the
+variable data in **separate JSON fields**:
+
+**JVM (Kotlin)**
+
+```kotlin
+// BAD — the id in the message fragments grouping
+log.error("Failed to fetch behandling $behandlingId")
+// GOOD — stable message; id as a structured field (StructuredArguments.kv)
+log.error("Failed to fetch behandling", kv("behandlingId", behandlingId), e)
 ```
 
-The [auto-instrumentation](../../how-to/auto-instrumentation.md) Java agent
-includes a Logback/Log4j appender bridge. When log export is enabled, every log
-event goes to the OpenTelemetry collector as a structured log record — and when
-the event carries a `Throwable`, the appender attaches the semantic-convention
-exception attributes automatically:
+**Node.js (Pino)**
 
-- `exception.type`
-- `exception.message`
-- `exception.stacktrace`
+```javascript
+// BAD — id in the message fragments grouping
+logger.error(`Failed to fetch behandling ${behandlingId}`);
+// GOOD — stable message, id as a field, error as an object
+logger.error({ behandlingId, err }, "Failed to fetch behandling");
+```
 
-The collector forwards log records to Loki's OTLP endpoint, which stores log
-attributes as **structured metadata**, normalizing dots to underscores. So
-`exception.type` becomes the `exception_type` label the Issues tab groups on.
-Nothing in the app needs to know the semconv field names — logging with the
-throwable is enough.
+### 3. Log the exception as an object
 
-!!! note "This is the same lever for any JVM logging framework"
-    The bridge instruments **Logback** and **Log4j2** (and anything on SLF4J
-    that routes to them). Spring Boot and Ktor both use SLF4J + Logback by
-    default, so the exact same two steps below work for both: enable OTLP log
-    export, and log exceptions *with the throwable*.
+Pass the throwable / `Error` object to the logger — never a string you built from
+it. On the stdout path this puts the exception's **stack trace** into the JSON
+line, which the Issues tab's occurrence drawer reads from a top-level
+`stack_trace` or `stack` field:
 
-!!! note "Node.js is automatic too; Go is manual"
-    Node.js reaches shape A the same way — the auto-instrumentation's Winston or
-    Pino appender attaches `exception.*` when you log an `Error` object (see
-    [Node.js and Express](#nodejs-and-express)). Go has **no** platform agent and
-    no automatic error mapping, so you set the `exception.*` attributes yourself
-    (see [Go (net/http)](#go-nethttp)).
+- `logstash-logback-encoder` writes the stack to `stack_trace` automatically.
+- Winston with `format.errors({ stack: true })` writes a top-level `stack`.
+- Pino nests it under `err.stack`; add a top-level `stack` (or a custom
+  serializer) if you want it in the drawer.
 
-## Spring Boot (Kotlin / Java)
+!!! note "What shape B gives you — and what it doesn't"
+    Shape B groups by **message only**. The exception **class** is *not* used for
+    grouping and is *not* shown in the occurrence detail on this path — only the
+    OpenTelemetry path (shape A) carries the class. So on stdout your two levers
+    are a **stable message** (tight grouping) and the **stack trace** in the
+    drawer. That's a solid backend Issue; it just isn't the full shape A.
 
-### 1. Enable auto-instrumentation and OTLP log export
+## Reach shape A with OpenTelemetry log export (one option)
 
-You need the Java agent (for the appender bridge) and the opt-in log exporter.
-In `nais.yaml`:
+If you already use OpenTelemetry logs, or you're willing to dual-ship, exporting
+logs over OTLP is the only way to reach **shape A** today. The collector sends
+each log record to Loki's OTLP endpoint, which stores the semantic-convention
+exception attributes as structured metadata:
+
+- `exception.type` → `exception_type`
+- `exception.message` → `exception_message`
+- `exception.stacktrace` → `exception_stacktrace`
+
+The Issues tab then groups on `exception_type` + `exception_message`, with the
+class and full stack trace in each Issue.
+
+!!! warning "This takes over your logs"
+    `OTEL_LOGS_EXPORTER=otlp` sends **all** your logs through the collector and is
+    not compatible with [Team Logs](../../logging/how-to/team-logs.md). Your
+    container also keeps writing to stdout, so lines can land in Loki twice (see
+    [Known limitations](#known-limitations-and-cost)). This is why most teams stay
+    on the stdout path — enable OTLP only if you actively want it.
+
+### JVM (Spring Boot and Ktor)
+
+Enable the Java agent's log bridge and log with the throwable. In `nais.yaml`:
 
 ```yaml title="nais.yaml"
 spec:
@@ -95,38 +138,14 @@ spec:
       value: otlp
 ```
 
-`OTEL_LOGS_EXPORTER` defaults to `none`; setting it to `otlp` is what turns on
-the log bridge. See the
-[auto-instrumentation reference](../../reference/auto-config.md#logs-auto-instrumentation).
+The [auto-instrumentation](../../how-to/auto-instrumentation.md) Java agent
+bridges Logback/Log4j2 to OTel logs; when a log event carries a `Throwable`, the
+appender attaches `exception.type/message/stacktrace` automatically. Spring Boot
+and Ktor both use SLF4J + Logback by default, so logging the throwable is all you
+need — no `logback.xml` change or extra dependency.
 
-!!! warning "Not compatible with Team Logs"
-    Enabling OTLP log export sends **all** your logs through the collector. Do
-    not combine it with [Team Logs](../../logging/how-to/team-logs.md), and read
-    [Known limitations](#known-limitations-and-cost) below on log duplication
-    before rolling it out widely.
-
-### 2. Log exceptions with the throwable
-
-Shape A only happens when the log event actually carries the exception object.
-Pass the `Throwable` as the last argument — never string-interpolate it:
-
-```kotlin
-private val log = LoggerFactory.getLogger(OrderService::class.java)
-
-try {
-    processOrder(order)
-} catch (e: OrderException) {
-    // GOOD — the throwable is captured → exception.type/message/stacktrace
-    log.error("Failed to process order {}", order.id, e)
-
-    // BAD — the stack trace ends up as plain text in the message, shape C
-    // log.error("Failed to process order ${order.id}: ${e.stackTraceToString()}")
-}
-```
-
-For exceptions that escape your controllers, add a
-`@RestControllerAdvice` handler so they are logged once, with the throwable, at
-`ERROR`:
+Log what escapes your handlers once, with the throwable. Spring — a
+`@RestControllerAdvice`:
 
 ```kotlin
 @RestControllerAdvice
@@ -141,23 +160,7 @@ class GlobalExceptionHandler {
 }
 ```
 
-That's it — no `logback.xml` changes and no extra dependency are required for the
-exception fields. The agent's appender adds them.
-
-## Ktor
-
-Ktor has no logging framework of its own: it logs through **SLF4J**, and the
-standard Ktor project ships **logback-classic** as the binding. That means the
-same Java-agent appender bridge applies — the two steps are identical.
-
-### 1. Enable auto-instrumentation and OTLP log export
-
-Same `nais.yaml` as Spring Boot above (`runtime: java`, `OTEL_LOGS_EXPORTER=otlp`).
-
-### 2. Log exceptions with the throwable
-
-Use the **StatusPages** plugin as the single place that turns an unhandled
-exception into a logged `Throwable`:
+Ktor — the `StatusPages` plugin:
 
 ```kotlin
 install(StatusPages) {
@@ -168,37 +171,16 @@ install(StatusPages) {
 }
 ```
 
-Anywhere else you catch, log the same way — the throwable as the last argument:
-
-```kotlin
-val log = LoggerFactory.getLogger("PaymentRoute")
-
-try {
-    charge(request)
-} catch (e: PaymentException) {
-    log.error("Charge failed for {}", request.id, e)
-    call.respond(HttpStatusCode.BadGateway)
-}
-```
-
-!!! note "If your Ktor app doesn't use Logback"
-    Confirm `ch.qos.logback:logback-classic` (or Log4j2) is on the classpath. If
-    you use a different SLF4J binding, the agent has no appender to bridge and
-    you'll stay in shape C. Logback is the Ktor default, so most apps already
+!!! note "Confirm your SLF4J binding"
+    The agent can only bridge **Logback** or **Log4j2**. If your app uses a
+    different SLF4J binding there is no appender to bridge and you'll stay in
+    shape C. Logback is the Spring Boot and Ktor default, so most apps already
     have it.
 
-## Node.js and Express
+### Node.js (Express / Next.js)
 
-Node has no bytecode agent like the JVM, but the `runtime: nodejs`
-[auto-instrumentation](../../how-to/auto-instrumentation.md) is the OpenTelemetry
-Node SDK plus the auto-instrumentations bundle — and that bundle includes the
-**Winston** and **Pino** instrumentations. Each of those has a log-sending
-appender that forwards your log records into the OTel logs pipeline, and on
-current versions it maps a logged `Error` onto the semantic-convention
-`exception.*` attributes for you. So the recipe is the same two steps: enable
-OTLP log export, and log the **`Error` object** — never a preformatted string.
-
-### 1. Enable auto-instrumentation and OTLP log export
+`runtime: nodejs` bundles the Winston and Pino instrumentations, whose
+log-sending appenders map a logged `Error` onto `exception.*` for you:
 
 ```yaml title="nais.yaml"
 spec:
@@ -211,224 +193,37 @@ spec:
       value: otlp
 ```
 
-Setting `OTEL_LOGS_EXPORTER=otlp` is what makes the Node SDK configure a logs
-provider for the Winston/Pino appenders to emit into; log sending is on by
-default once that provider exists.
-
-### 2. Log the `Error` object
-
-Pass the `Error` itself so the appender can read its name, message, and stack —
-don't interpolate it into the message string.
-
-With **Pino**, put the error under the `err` key (Pino's default error key):
+Log the `Error` object so the appender can read its name, message, and stack:
 
 ```javascript
-// GOOD — the Error under `err` → exception.type/message/stacktrace,
-// and `orderId` rides along as a structured attribute
-logger.error({ err, orderId: order.id }, "Failed to process order");
+// Pino: the Error under `err` → exception.type/message/stacktrace
+logger.error({ behandlingId, err }, "Failed to fetch behandling");
 
-// BAD — a preformatted string: no type, no stack → shape B
-// logger.error(`Failed to process order ${order.id}: ${err.message}`);
+// Winston: the Error passed alongside the message
+// logger.error("Failed to fetch behandling", { behandlingId, err });
 ```
 
-With **Winston**, pass the error alongside the message:
-
-```javascript
-// GOOD — the Error is picked up from the log arguments → exception.* attributes
-logger.error("Failed to process order", { orderId: order.id, err });
-
-// BAD — string interpolation, no exception metadata → shape B
-// logger.error(`Failed to process order ${order.id}: ${err.message}`);
-```
-
-The natural place to catch what escapes your routes is the Express
-**error-handling middleware** — the four-argument handler `(err, req, res, next)`,
-registered after all your routes:
+The four-argument Express **error-handling middleware** `(err, req, res, next)`,
+registered after your routes, is the natural place to catch what escapes a route
+(the same appender applies to Next.js route handlers and API routes):
 
 ```javascript
 app.use((err, req, res, next) => {
-    logger.error({ err }, "Unhandled error"); // Winston: logger.error("Unhandled error", { err })
+    logger.error({ err }, "Unhandled error");
     res.status(500).send("Internal Server Error");
 });
 ```
 
 !!! note "Check your OpenTelemetry versions"
-    The automatic `Error` → `exception.*` mapping is a recent addition
-    (OpenTelemetry JS `api-logs`/`sdk-logs` ≥ 0.212.0, which the platform's
-    `nodejs` agent bundles). On older self-managed pins the `Error` was copied as
-    a generic attribute instead, leaving you in shape B. If you emit your own log
-    records with `@opentelemetry/api-logs`, you can set it explicitly by passing
-    the error as the record's `exception` field:
-    `logger.emit({ severityNumber: SeverityNumber.ERROR, body: err.message, exception: err })`.
+    The automatic `Error` → `exception.*` mapping needs OpenTelemetry JS
+    `api-logs`/`sdk-logs` ≥ 0.212.0 (bundled by the platform `nodejs` agent). On
+    older self-managed pins the `Error` is copied as a generic attribute instead,
+    leaving you in shape B. You can always set it explicitly by passing the error
+    as the log record's `exception` field via `@opentelemetry/api-logs`.
 
-## Go (net/http)
+### Field mapping
 
-Go is different in two ways, and it's worth being honest about both.
-
-First, there is **no Go agent**. The `runtime: sdk`
-[auto-instrumentation](../../how-to/auto-instrumentation.md) mode sets the
-OpenTelemetry environment variables (including the OTLP endpoint) but injects
-nothing into your process — your app wires the OpenTelemetry SDK itself, so you
-configure the logs pipeline in code.
-
-Second, **nothing maps a Go `error` to `exception.*` for you**, and a Go `error`
-carries no stack trace the way a Java `Throwable` does. You can still reach shape
-A on `exception.type` and `exception.message` — which is what the Issues tab
-groups on — but you set those attributes yourself, and a real stack trace takes
-extra work.
-
-### 1. Wire the logs SDK and bridge `slog` to it
-
-Build a `LoggerProvider` with the OTLP log exporter and route `slog` through the
-[`otelslog`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog)
-bridge. The OpenTelemetry Go **logs** signal is still beta (`v0.x` modules), but
-it is usable in production:
-
-```go
-import (
-    "context"
-    "log/slog"
-
-    "go.opentelemetry.io/contrib/bridges/otelslog"
-    "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
-    sdklog "go.opentelemetry.io/otel/sdk/log"
-    "go.opentelemetry.io/otel/sdk/resource"
-)
-
-func setupLogging(ctx context.Context, res *resource.Resource) (*sdklog.LoggerProvider, error) {
-    // otlploggrpc reads the OTEL_EXPORTER_OTLP_* env vars that `runtime: sdk` injects.
-    exporter, err := otlploggrpc.New(ctx)
-    if err != nil {
-        return nil, err
-    }
-    provider := sdklog.NewLoggerProvider(
-        sdklog.WithResource(res), // the same resource you build for traces (service.name / namespace)
-        sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter)),
-    )
-    // Route the standard-library slog through the bridge.
-    slog.SetDefault(otelslog.NewLogger("my-app", otelslog.WithLoggerProvider(provider)))
-    return provider, nil // remember to defer provider.Shutdown(ctx)
-}
-```
-
-### 2. Log the error with `exception.*` attributes
-
-The bridge copies `slog` attribute keys through verbatim and does **not**
-special-case errors — so name the attributes with the exact semantic-convention
-keys and they land as the `exception_type` / `exception_message` structured
-metadata the Issues tab needs:
-
-```go
-func handleOrder(w http.ResponseWriter, r *http.Request) {
-    if err := processOrder(r.Context(), order); err != nil {
-        // GOOD — exception.type + exception.message → shape A grouping,
-        // order.id rides along as its own structured attribute
-        slog.ErrorContext(r.Context(), "failed to process order",
-            slog.String("order.id", order.ID),
-            slog.String("exception.type", fmt.Sprintf("%T", err)),
-            slog.String("exception.message", err.Error()),
-        )
-
-        // BAD — the error folded into the message: no type, fragmented grouping → shape B
-        // slog.Error("failed to process order " + order.ID + ": " + err.Error())
-
-        http.Error(w, "internal error", http.StatusInternalServerError)
-        return
-    }
-}
-```
-
-!!! warning "Stack traces are weaker in Go — be realistic"
-    A Go `error` has no stack, so `exception.stacktrace` is **not** populated for
-    you. If you need it you must capture it yourself with `runtime.Stack`, but
-    that gives the *current* goroutine's stack at the log call — not where the
-    error originated — so it's far less useful than a JVM stack trace. An error
-    library that records a stack at creation (for example `pkg/errors` or
-    `cockroachdb/errors`) is a better source; format its stack into
-    `slog.String("exception.stacktrace", …)`. Separately,
-    `span.RecordError(err, trace.WithStackTrace(true))` records the exception on
-    the current **span** (visible in the trace), independent of the log record
-    above. Type + message alone is still enough to land in shape A.
-
-## Log the exception, not a bare message
-
-This is the single biggest reason backend Issues come out thin, and it applies to
-every runtime above. Everything hinges on one habit: **hand the logging framework
-the throwable/error object, not a string you built from it.** The moment you
-pre-format the error into the message, its type and stack are gone and Loki only
-ever sees text — you drop from shape A to shape B (or, on stdout, shape C).
-
-### Log the object, never a pre-formatted string
-
-Bad first, good second, per runtime:
-
-**JVM (Kotlin)**
-
-```kotlin
-// BAD  — type and stack lost inside a string
-log.warn("Failed to fetch $url: ${e.message}")
-// GOOD — throwable as the last argument, url as a parameter
-log.warn("Failed to fetch {}", url, e)
-```
-
-**Node.js (Pino)**
-
-```javascript
-// BAD
-logger.warn(`Failed to fetch ${url}: ${err.message}`);
-// GOOD
-logger.warn({ err, url }, "Failed to fetch");
-```
-
-**Go**
-
-```go
-// BAD
-slog.Warn("failed to fetch " + url + ": " + err.Error())
-// GOOD
-slog.Warn("failed to fetch",
-    slog.String("url", url),
-    slog.String("exception.type", fmt.Sprintf("%T", err)),
-    slog.String("exception.message", err.Error()),
-)
-```
-
-### Don't log self-healing retries at error or warn
-
-A message that logs on every retry and then recovers is still counted as an
-Issue — often a *top* Issue — even though nothing was ever actually broken. Log
-retries at `info`/`debug`, and only escalate to `error` when the **final**
-attempt fails:
-
-```javascript
-async function fetchWithRetry(url, attempts = 3) {
-    for (let i = 1; i <= attempts; i++) {
-        try {
-            return await fetch(url);
-        } catch (err) {
-            if (i === attempts) {
-                // only the terminal failure becomes an Issue
-                logger.error({ err, url, attempts }, "Fetch failed after retries");
-                throw err;
-            }
-            // transient, self-healing — not an Issue
-            logger.debug({ url, attempt: i }, "Fetch failed, retrying");
-        }
-    }
-}
-```
-
-### Put context in attributes, not in the message
-
-Add identifiers and status as **structured fields** (`url`, `status`, `orderId`)
-rather than concatenating them into the message string. Two payoffs: they become
-queryable structured metadata in Loki, and — because the Issues tab groups on
-message + type — keeping variable data out of the message stops one error from
-fragmenting into dozens of near-duplicate issues.
-
-## Field mapping
-
-What the app produces, and how it lands in the Issues tab:
+What the app produces on the OTLP path, and how it lands in the Issues tab:
 
 | OTel log attribute (semconv) | Loki structured metadata | Used by Issues for |
 |------------------------------|--------------------------|--------------------|
@@ -445,44 +240,140 @@ sum by (exception_type, exception_message) (
 )
 ```
 
+## Go
+
+Go is a smaller slice of nais apps and largely the platform team's domain, so
+briefly: Go uses `runtime: sdk` — no agent — so your app wires OpenTelemetry
+itself. For the stdout path the same shape-B advice applies (structured JSON,
+stable message, error as a field). For shape A you build a `LoggerProvider` with
+the OTLP log exporter and the
+[`otelslog`](https://pkg.go.dev/go.opentelemetry.io/contrib/bridges/otelslog)
+bridge, then set the `exception.*` attributes yourself — the bridge does not map
+errors, and because a Go `error` carries no stack, `exception.stacktrace` is
+manual and weaker than the JVM's:
+
+```go
+slog.ErrorContext(ctx, "failed to fetch behandling",
+    slog.String("behandlingId", behandlingId),
+    slog.String("exception.type", fmt.Sprintf("%T", err)),
+    slog.String("exception.message", err.Error()),
+)
+```
+
+## Log the exception, not a bare message
+
+Whichever path you're on, this is the single biggest reason backend Issues come
+out thin: **hand the logging framework the throwable/error object, not a string
+you built from it**, and keep the message stable.
+
+### Log the object, never a pre-formatted string
+
+**JVM (Kotlin)**
+
+```kotlin
+// BAD  — class and stack lost inside a string
+log.warn("Failed to fetch behandling $behandlingId: ${e.message}")
+// GOOD — stable message, throwable as the last arg, id as a field
+log.warn("Failed to fetch behandling", kv("behandlingId", behandlingId), e)
+```
+
+**Node.js (Pino)**
+
+```javascript
+// BAD
+logger.warn(`Failed to fetch behandling ${behandlingId}: ${err.message}`);
+// GOOD
+logger.warn({ behandlingId, err }, "Failed to fetch behandling");
+```
+
+### Don't log self-healing retries at error or warn
+
+A message that logs on every retry and then recovers is still counted as an
+Issue — often a *top* Issue — even though nothing was actually broken. Log
+retries at `info`/`debug`, and only escalate to `error` when the **final**
+attempt fails. For example, a client calling the Oppgave API:
+
+```javascript
+async function createOppgave(payload, attempts = 3) {
+    for (let i = 1; i <= attempts; i++) {
+        try {
+            return await oppgaveClient.create(payload);
+        } catch (err) {
+            if (i === attempts) {
+                // only the terminal failure becomes an Issue
+                logger.error({ err, saksId: payload.saksId, attempts }, "Failed to create oppgave");
+                throw err;
+            }
+            // transient, self-healing — not an Issue
+            logger.debug({ saksId: payload.saksId, attempt: i }, "Oppgave call failed, retrying");
+        }
+    }
+}
+```
+
+### Put context in fields, not in the message
+
+Add identifiers and status as **structured fields** (`saksId`, `behandlingId`,
+`journalpostId`, `oppgaveId`, `status`) rather than concatenating them into the
+message. They become queryable, and — because grouping is on the message —
+keeping variable data out of the message keeps one error from fragmenting into
+dozens of near-duplicate Issues.
+
+!!! danger "Never log personally identifying data"
+    Do **not** put `fnr`/`personident`, names, addresses, or other directly
+    identifying data into log messages or fields. Internal case identifiers like
+    `saksId` / `behandlingId` are acceptable **only** when they don't themselves
+    identify the user or leak personal data. When in doubt, leave it out.
+
 ## Verify it works
 
 1. Trigger the exception in your app (dev is fine).
 2. In [Grafana Explore](<<tenant_url("grafana", "explore")>>), pick your
-   environment's Loki data source and run:
+   environment's Loki data source and check which shape you're in.
+
+    **Shape B (stdout):**
+
+    ```logql
+    {service_name="<your-app>", service_namespace="<your-team>"} | json | detected_level=~"(?i)error"
+    ```
+
+    You should see your JSON body parsed, with a stable `message`/`msg` and — if
+    you logged the object — a `stack_trace`/`stack` field.
+
+    **Shape A (OpenTelemetry):**
 
     ```logql
     {service_name="<your-app>", service_namespace="<your-team>"} | exception_type != ""
     ```
 
-    Expand a result line: you should see `exception_type`, `exception_message`,
-    and `exception_stacktrace` under **structured metadata** (not inside the log
-    body). If they're there, you're in shape A.
+    Expand a line — `exception_type`, `exception_message`, and
+    `exception_stacktrace` should appear under **structured metadata** (not inside
+    the log body). If they're there, you're in shape A.
 
 3. Open your service's **Issues** tab in
    [Nais APM](<<tenant_url("grafana", "a/nais-apm-app")>>). Within a few minutes
-   the exception should appear as a backend issue with its type, message, stack
-   trace, and a pod-impact count.
+   the exception should appear as a backend Issue.
 
-If you see the log lines but no `exception_*` metadata, the event was logged
-without the error object — on the JVM, without the throwable or via a
-non-Logback/Log4j binding; on Node.js, as a preformatted string instead of the
-`Error`; on Go, without the `exception.*` attributes — so revisit step 2 of the
-relevant section.
+If you're on stdout and one error fragments into near-duplicate Issues, your
+message is carrying variable data — revisit
+[step 2](#get-the-best-issues-over-stdout-shape-b).
 
 ## Known limitations and cost
 
-- **Log duplication.** Enabling `OTEL_LOGS_EXPORTER=otlp` does **not** stop your
-  container from writing to stdout, and fluentbit keeps shipping stdout to Loki.
-  So each log line can land in Loki twice: once from stdout, once over OTLP. This
-  increases log volume (and cost). Keep your console logging lean when you turn
-  this on.
-- **A possible duplicate issue.** If your stdout logging is JSON (for example
-  logstash-logback-encoder on the JVM, or Pino/Winston JSON on Node.js) *and* you
-  enable OTLP export, the same exception can
-  surface as **two** issues: the rich shape-A issue (from the OTLP copy) and a
-  weaker message-only shape-B issue (from the stdout JSON copy). This is a known
-  rough edge — see the platform follow-up below.
+- **Shape A needs OpenTelemetry today.** There is no way to reach shape A on the
+  stdout path: fluentbit attaches only Kubernetes fields as structured metadata
+  and never promotes app JSON fields like `exception_type`. A platform change —
+  fluentbit promoting `exception.*`/`error.*` JSON fields to Loki structured
+  metadata — would let stdout apps reach shape A without OTLP, but that is a
+  **follow-up and not available today**.
+- **Log duplication (OTLP).** Enabling `OTEL_LOGS_EXPORTER=otlp` does not stop
+  your container writing to stdout, and fluentbit keeps shipping it — so each line
+  can land in Loki twice, once from stdout and once over OTLP. Keep console
+  logging lean if you turn it on.
+- **A possible duplicate Issue (OTLP).** If your stdout logging is JSON *and* you
+  enable OTLP export, the same exception can surface as **two** Issues: the rich
+  shape-A Issue (from the OTLP copy) and a weaker message-only shape-B Issue (from
+  the stdout JSON copy).
 
 ## Related
 
@@ -491,5 +382,5 @@ relevant section.
 - [Auto-instrumentation reference](../../reference/auto-config.md) — the
   `OTEL_LOGS_EXPORTER` opt-in and other agent settings.
 - [Loki labels reference](../../logging/reference/loki-labels.md) — what
-  structured metadata is.
+  structured metadata is, and which fields are available.
 - [Triage an issue](triage-an-issue.md) — acting on the issue once it's grouped.


### PR DESCRIPTION
Extends the (already merged) **Get backend exceptions into Issues** how-to so it covers more runtimes beyond Spring Boot + Ktor, and names the #1 reason backend Issues come out thin.

## What's added

- **Node.js and Express** — `runtime: nodejs` auto-instrumentation + `OTEL_LOGS_EXPORTER=otlp`. The bundled Winston/Pino log-sending appenders map a logged `Error` onto the semconv `exception.*` attributes (Pino `err` key / Winston log args), so the same two-step recipe reaches shape A. Express 4-arg error middleware `(err, req, res, next)` as the natural capture point. Includes a version note: the automatic `Error → exception.*` mapping requires OTel JS `api-logs`/`sdk-logs` ≥ 0.212.0 (which the platform `nodejs` agent bundles).
- **Go (net/http)** — `runtime: sdk` (no agent; app wires the SDK itself). Sets up `otel/log` + `sdk/log` + `otlploggrpc` and the `otelslog` bridge, then sets `exception.*` explicitly because the bridge does not special-case errors. Honest admonition that Go errors carry no stack trace, so `exception.stacktrace` is manual and weaker than the JVM agent; type + message alone still land in shape A.
- **Log the exception, not a bare message** — cross-runtime anti-pattern section: log the throwable/error object (not a preformatted string), don't log self-healing retries at error/warn, and put context (`url`, `status`, `orderId`) in attributes rather than the message.

Also broadens the intro, frontmatter description, the verify-troubleshooting line, and the duplicate-issue note to cover all three runtimes. Structure, tone, shape-A/B/C framing, and nav-gating are unchanged.

## Verification

- `mise run build nav ssb` — green (exit 0).
- Page renders for **nav** (`nav/observability/apm/how-to/backend-exceptions-as-issues/`) and is **absent for ssb** (whole APM section is nav-gated via `docs/observability/apm/.pages`).
- New heading anchors (`#nodejs-and-express`, `#go-nethttp`) resolve; intra-page links match. No leftover template tokens (`tenant_url` renders to real URLs).

## API accuracy notes

Every snippet is grounded in the current OTel APIs (verified against pkg.go.dev / npm / the OTel repos), and the doc flags the load-bearing uncertainties inline: the Node exception-mapping **version requirement**, and Go's **beta logs signal** + **manual, weaker stack-trace capture**.