### PR TITLE
docs(frontend): PII warning + @nais/apm path for custom metrics

### DIFF
--- a/docs/observability/frontend/how-to/custom-metrics.md
+++ b/docs/observability/frontend/how-to/custom-metrics.md
@@ -7,6 +7,35 @@ tags: [how-to, observability, frontend, metrics]
 
 Faro can send custom numeric measurements from the browser to Loki. Use this to track application-specific metrics like load times for specific components, feature usage counts, or business-relevant durations.
 
+!!! warning "Never put personal data in a custom measurement"
+    Measurement **values**, event attributes, and everything you pass as
+    `context` are written verbatim to **shared observability storage (Loki)**
+    that every team on the platform can query. Treat a custom measurement like a
+    public log line.
+
+    **Never** put a `fødselsnummer`, a name, an address, or any other
+    personopplysning into a measurement value, a `context_*` field, an event
+    attribute, or `setUser`. Use only opaque, non-identifying keys — a hashed or
+    otherwise non-reversible id instead of a raw user identifier, and a category
+    instead of a person.
+
+    The ingestion pipeline scrubs 11-digit fødselsnummer as a defense-in-depth
+    backstop, but it is regex-based and you **must not rely on it**: it cannot
+    catch names, addresses, or free text, and it does not touch numeric
+    measurement values at all.
+
+{% if tenant() == "nav" %}
+!!! danger "Personvern: NAV-identer and names are never scrubbed"
+    Real NAV personopplysninger have already leaked into shared Loki through
+    custom telemetry. Beyond fødselsnummer, **never** put **NAV-identer
+    (Z-/NAV-numre)**, employee or citizen names, `enhet`-/office names, or case
+    details into measurement values, `context_*`, event attributes, or
+    `setUser`. Regex scrubbing **cannot** catch any of these — only fødselsnummer
+    is scrubbed, and only as a backstop. This is the same rule the
+    [`@nais/apm` Privacy section](../../apm/reference/apm-client-api.md#privacy-pii-scrubbing)
+    applies to `setUser`: prefer a hashed or opaque id.
+{% endif %}
+
 ## Send a measurement
 
 Use `faro.api.pushMeasurement` to send named numeric values:
@@ -21,6 +50,37 @@ faro.api.pushMeasurement({
   },
 });
 ```
+
+{% if tenant() == "nav" %}
+!!! tip "Using `@nais/apm`? Reach `pushMeasurement` through `init()`"
+    nais browser apps set up telemetry through
+    [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md), which
+    **deliberately does not wrap** `pushMeasurement` / `pushEvent`. Its `init()`
+    returns the underlying Faro instance — call the raw Faro API on that value
+    rather than importing a separate `faro` singleton:
+
+    ```js
+    import { init } from '@nais/apm';
+
+    // Call once at app startup; returns the underlying Faro instance.
+    // Calling init() again elsewhere safely returns the same instance.
+    const faro = init();
+
+    faro.api.pushMeasurement({
+      type: 'custom',
+      values: { search_results_ms: 342 },
+    });
+    ```
+
+    `@nais/apm`'s PII scrubbing runs inside its Faro `beforeSend` and only
+    rewrites fødselsnummer, emails, and token URL parameters. It does **not**
+    clean numeric measurement values and never catches NAV-identer or names, so
+    custom measurements and events get **no meaningful PII protection** from the
+    wrapper — the warning above applies in full.
+
+    Manual custom **spans** aren't supported by `@nais/apm` either: browser
+    tracing is automatic only, so there is no custom-span API to reach for.
+{% endif %}
 
 You can send multiple values in a single measurement:
 


### PR DESCRIPTION
Custom `pushMeasurement` / `pushEvent` data goes to **shared Loki**, and real NAV personopplysninger have leaked there through custom telemetry (e.g. NAV-identer, names, enhet names). Regex scrubbing catches only fødselsnummer (as a best-effort backstop being added pipeline-side) and never catches idents or names — so developer guidance is the real control.

## Changes to `docs/observability/frontend/how-to/custom-metrics.md`

**1. Prominent PII / personvern warning**
- Ungated `!!! warning`: measurement values, event attributes and `context` are written verbatim to shared Loki; never put fødselsnummer, names, addresses or other personopplysninger in measurement values, `context_*`, event attributes or `setUser`; use opaque/hashed ids. Notes fnr is scrubbed only as a defense-in-depth backstop you must not rely on.
- Nav-gated `!!! danger`: adds NAV-identer (Z-/NAV-numre), names and enhet names to the never-list, states idents/names are never scrubbed, and links the [`@nais/apm` Privacy section](https://github.com/nais/doc/blob/main/docs/observability/apm/reference/apm-client-api.md) for the same `setUser` rule.

**2. Fix the `@nais/apm` gap**
- The guide only showed `import { faro } from "@grafana/faro-web-sdk"`. nais apps init through `@nais/apm`, which deliberately does **not** wrap `pushMeasurement`/`pushEvent`. Added a nav-gated tip showing the correct path — `const faro = init(); faro.api.pushMeasurement(...)` (the wrapper `init()` returns the Faro instance) — and noting its scrubber gives custom measurements no meaningful PII protection.

**3. No custom spans**
- Noted that manual custom spans are not supported by `@nais/apm` (tracing is auto-only).

## Gating / build
The `apm/` subtree is nav-only (`.pages` `conditional: [tenant, nav]`), so all `@nais/apm` guidance and the apm-reference link are `{% if tenant() == "nav" %}`-gated; the general personopplysninger warning stays visible to all tenants. `mise run build nav ssb` is green with no new broken-link/token warnings, and the apm link resolves in nav and is absent (not broken) in ssb.