### PR TITLE
docs(frontend): complete sourcemap upload + container guide

### DIFF
--- a/docs/observability/frontend/how-to/sourcemaps.md
+++ b/docs/observability/frontend/how-to/sourcemaps.md
@@ -74,6 +74,65 @@ Production sourcemaps often need explicit configuration. Verify your bundler gen
 !!! warning "Sourcemaps must be accessible to the collector"
     The collector fetches `.map` files using the `sourceMappingURL` comment in your JavaScript bundle. If you use `hidden-source-map` (which omits that comment), the collector can't find the map files and stack traces won't be deobfuscated. Use the default `source-map` setting, or `productionBrowserSourceMaps: true` for Next.js.
 
+## Upload the bundle and sourcemaps to the CDN
+
+Building `.map` files is only half the job — the collector can only fetch them if both the JavaScript **and** its `.map` file are served from the CDN. Publish your build output with the [CDN upload action](../../../services/cdn/how-to/upload-assets.md). Add a step to the GitHub workflow that builds your frontend:
+
+```yaml
+- uses: nais/deploy/actions/cdn-upload/v2@master
+  with:
+{%- if tenant() != "nav" %}
+    tenant: <<tenant()>>
+{%- endif %}
+    team: <team>
+    source: dist
+    destination: /<app>/dist
+```
+
+`source` is your build output directory (`dist` for Vite, `build` for Create React App, `.next/static` for Next.js), and `destination` is the path under your team's CDN prefix. See [Upload assets to the CDN](../../../services/cdn/how-to/upload-assets.md) for the full workflow (repository authorization, permissions, and every input the action accepts).
+
+!!! note "Upload the whole build output"
+    Point `source` at the directory that holds both the `.js` files and their sibling `.map` files, so they land on the CDN together. Don't strip the `.map` files out of the artifact before uploading.
+
+### Where the files land
+
+With the step above, your build output is served from:
+
+{% if tenant() == "nav" %}
+```
+https://cdn.nav.no/<team>/<app>/dist/main.[hash].js
+https://cdn.nav.no/<team>/<app>/dist/main.[hash].js.map
+```
+{% else %}
+```
+https://cdn.<<tenant()>>.cloud.nais.io/<team>/<app>/dist/main.[hash].js
+https://cdn.<<tenant()>>.cloud.nais.io/<team>/<app>/dist/main.[hash].js.map
+```
+{% endif %}
+
+The `.js` file carries a relative `//# sourceMappingURL=main.[hash].js.map` comment, and the `.map` file sits right next to it — so the collector resolves it from the same directory.
+
+!!! warning "The browser must load the JS from the CDN URL"
+    {% if tenant() == "nav" -%}
+    Resolution only triggers when the browser actually downloads the JavaScript from its `cdn.nav.no` URL. The collector looks at the origin of each stack frame's file and only resolves frames whose file is served from `cdn.nav.no`.
+    {%- else -%}
+    Resolution only triggers when the browser actually downloads the JavaScript from its `cdn.<<tenant()>>.cloud.nais.io` URL. The collector looks at the origin of each stack frame's file and only resolves frames whose file is served from the CDN.
+    {%- endif %} Uploading the map to the CDN does nothing on its own — your HTML must reference the bundle by its CDN URL, not a copy served from your pod.
+
+## Put it all together
+
+The end-to-end flow:
+
+1. **Build** emits `.js` bundles, sibling `.map` files, and a relative `//# sourceMappingURL=` comment in each bundle (see [Build configuration](#build-configuration)).
+2. **CI uploads** the whole build output — JavaScript **and** `.map` files — to the CDN with the [`cdn-upload`](#upload-the-bundle-and-sourcemaps-to-the-cdn) step.
+{% if tenant() == "nav" -%}
+3. **Your app references the JavaScript by its `cdn.nav.no` URL** — the `<script src>` (or bundler `base` / `publicPath`) points at `https://cdn.nav.no/<team>/<app>/dist/...`, so the browser loads it from the CDN.
+{%- else -%}
+3. **Your app references the JavaScript by its CDN URL** — the `<script src>` (or bundler `base` / `publicPath`) points at `https://cdn.<<tenant()>>.cloud.nais.io/<team>/<app>/dist/...`, so the browser loads it from the CDN.
+{%- endif %}
+4. **An error fires**, and because the frame's file is served from the CDN the collector follows its `sourceMappingURL`, fetches the sibling `.map`, and stores the resolved stack trace.
+5. **Verify** the resolved trace shows up in Grafana (see [Verify it works](#verify-it-works)).
+
 ## What happens when resolution fails
 
 If the collector can't fetch or parse a sourcemap, it falls back to minified output:
@@ -105,3 +164,23 @@ If you see minified output instead, check [Troubleshooting](../reference/trouble
 {% if tenant() == "nav" %}
 Resolved stack traces also appear on each error in the Nais APM [Issues tab](../../apm/tutorials/get-started.md#3-check-the-issues-tab), with your own code highlighted. Deobfuscation is server-side, so it works the same whether you instrument with raw Faro or [`@nais/apm`](../../apm/tutorials/track-frontend-errors.md#5-ship-readable-stack-traces).
 {% endif %}
+
+## My app runs in a container
+
+If your frontend is served from a pod — a server-rendered app (Next.js, Remix, SvelteKit) or any container that ships its own `.js` assets — then uploading `.map` files to the CDN does **nothing** on its own.
+
+{% if tenant() == "nav" -%}
+The reason is the origin match: the collector only resolves a stack frame when that frame's JavaScript file is served from `cdn.nav.no`. Frames whose files are served from your pod never trigger resolution, no matter where the `.map` file lives.
+{%- else -%}
+The reason is the origin match: the collector only resolves a stack frame when that frame's JavaScript file is served from `cdn.<<tenant()>>.cloud.nais.io`. Frames whose files are served from your pod never trigger resolution, no matter where the `.map` file lives.
+{%- endif %}
+
+**The supported recipe:** serve the static JavaScript (and its `.map` files) from the CDN even when the SSR shell runs in the pod. Most frameworks let you host client bundles on a separate asset host:
+
+- **Next.js** — set [`assetPrefix`](https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix) to your CDN URL, and upload `.next/static` to the CDN.
+- **Vite / SvelteKit** — set the [`base`](https://vitejs.dev/config/shared-options.html#base) (or adapter `paths.assets`) to your CDN URL, and upload the build output.
+
+The pod still renders the HTML shell, but the `<script>` tags point at the CDN, so the browser loads the bundles from there and the collector can resolve them.
+
+!!! note "Advanced: per-app origin override"
+    If you genuinely cannot serve your bundles from the CDN, an opt-in per-app `location` override in the collector's Faro sourcemap configuration can point resolution at a different origin. This is an advanced platform change rather than a self-service option — reach out to the Nais team before relying on it.

--- a/docs/observability/frontend/reference/troubleshooting.md
+++ b/docs/observability/frontend/reference/troubleshooting.md
@@ -55,11 +55,12 @@ If error stack traces show minified positions instead of source code:
 {% else %}
 1. **Check that your app is on the CDN** — sourcemap resolution only works for bundles served from `cdn.<<tenant()>>.cloud.nais.io`. Server-rendered apps (Next.js, Remix) serving assets from the pod are not supported
 {% endif %}
-2. **Check that sourcemaps are deployed** — your `.map` files must be on the CDN alongside the JS bundle
-3. **Check `sourceMappingURL`** — open your deployed JS bundle in a browser and look for `//# sourceMappingURL=` at the bottom. If it's missing, check your bundler config
-4. **Check the path** — the `sourceMappingURL` might be a relative path that doesn't resolve correctly from the collector's perspective
+2. **Check that sourcemaps are deployed** — your `.map` files must be on the CDN alongside the JS bundle. See [Upload the bundle and sourcemaps to the CDN](../how-to/sourcemaps.md#upload-the-bundle-and-sourcemaps-to-the-cdn)
+3. **Check that the browser loads the JS from the CDN** — resolution only triggers for frames whose file is served from the CDN. If your HTML references bundles served from your pod, uploading the maps to the CDN has no effect. See [My app runs in a container](../how-to/sourcemaps.md#my-app-runs-in-a-container)
+4. **Check `sourceMappingURL`** — open your deployed JS bundle in a browser and look for `//# sourceMappingURL=` at the bottom. If it's missing, check your bundler config
+5. **Check the path** — the `sourceMappingURL` might be a relative path that doesn't resolve correctly from the collector's perspective
 
-See [Sourcemaps](../how-to/sourcemaps.md) for build configuration details.
+See [Sourcemaps](../how-to/sourcemaps.md) for build configuration details and the [end-to-end walkthrough](../how-to/sourcemaps.md#put-it-all-together).
 
 ## High data volume
 


### PR DESCRIPTION
## What

The sourcemap deobfuscation how-to explained how resolution works and how to configure bundlers, but was missing the **upload half** and the **container-served** case. Teams reading it could build `.map` files but had no path to actually get them resolving.

This PR completes the guide.

## Changes

`docs/observability/frontend/how-to/sourcemaps.md`

- **Upload the bundle and sourcemaps to the CDN** — copy-pasteable `nais/deploy/actions/cdn-upload/v2` step (inputs confirmed against the [CDN upload reference](docs/services/cdn/reference/upload-assets.md)) and a link to the full [Upload assets to the CDN](docs/services/cdn/how-to/upload-assets.md) guide.
- **Where the files land** — concrete CDN path layout (`.../<app>/dist/main.[hash].js` + sibling `.map`) and the key requirement stated plainly: the browser must load the JS from the CDN URL, because resolution triggers on the frame file's origin.
- **Put it all together** — one numbered end-to-end walkthrough: build emits maps + relative `sourceMappingURL` → CI uploads JS **and** map → app references JS by its CDN URL → verify.
- **My app runs in a container** — explains that uploading maps does nothing if the JS is served from the pod (with the one-line origin-match reason), gives the supported recipe (serve static JS+map from the CDN even when the SSR shell runs in the pod, via `assetPrefix` / `base`), and notes the advanced opt-in per-app origin override.

`docs/observability/frontend/reference/troubleshooting.md`

- Cross-link "Sourcemaps not resolving" to the new upload and container sections, and add the browser-loads-from-CDN check.

## Verification

- nav gating (`{% if tenant() == "nav" %}`, `<<tenant()>>`) preserved; the upload step's `tenant:` line renders only for non-nav tenants.
- `mise run build nav ssb` is green; new heading anchors and cross-links resolve in both tenant builds.