### PR TITLE
Remove paired tags to prevent double rendering of text

### DIFF
--- a/docs/services/feature-toggling.md
+++ b/docs/services/feature-toggling.md
@@ -46,7 +46,7 @@ Each team has their own instance of Unleash. Each Unleash instance has two addre
 | `https://<team>-unleash-web.iap.nav.cloud.nais.io` | Web UI address | Internet            | `@nav.no` user |
 | `https://<team>-unleash-api.nav.cloud.nais.io/api` | API address    | nais and naisdevice | API token      |
 
-*replace `<team>` with your team name.*
+\*replace `<team>` with your team name.
 
 The web UI is used for viewing and managing feature toggles. The API is used by your application to fetch feature toggles.
 

--- a/docs/services/feature-toggling.md
+++ b/docs/services/feature-toggling.md
@@ -46,7 +46,7 @@ Each team has their own instance of Unleash. Each Unleash instance has two addre
 | `https://<team>-unleash-web.iap.nav.cloud.nais.io` | Web UI address | Internet            | `@nav.no` user |
 | `https://<team>-unleash-api.nav.cloud.nais.io/api` | API address    | nais and naisdevice | API token      |
 
-<sub>*replace `<team>` with your team name.</sub>
+*replace `<team>` with your team name.*
 
 The web UI is used for viewing and managing feature toggles. The API is used by your application to fetch feature toggles.
 


### PR DESCRIPTION
The custom renderer treats  `<sub>`  and  `</sub>`  as a paired HTML block and separately renders the content between them as Markdown. The nested  `<team>`  placeholder is also interpreted as an HTML element rather than ordinary text. That combination causes the generated output to be rendered incorrectly, making the line appear twice.

Use Markdown formatting instead of the HTML wrapper:

*Replace `<team>` with your team name.*

or escape the HTML tags if the smaller text is important:

<sub>*Replace* &lt;team&gt; with your team name.</sub>